### PR TITLE
fix: Update README and CLAUDE.md to reflect five-agent pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,9 @@ uv run python scripts/test_agents.py --agent design --dry-run
 The orchestrator builds a `StateGraph` with four sequential nodes connected by conditional edges. Each node calls its agent, updates shared state, and emits a heartbeat to the dashboard. The `should_continue` function routes based on `current_phase` in state (e.g., `design_complete` → `develop`, `develop_complete` → `testing`). On error, the workflow terminates early via the `END` edge.
 
 ```
-design_node → develop_node → testing_node → docs_node → END
+design_node → develop_node → code_review_node → testing_node → docs_node → END
+                                  ↑         │ (fail + iter ≤ max)
+                                  └─────────┘ (auto-fix loop)
 ```
 
 ### Shared State (`graph/state.py`)
@@ -50,7 +52,7 @@ design_node → develop_node → testing_node → docs_node → END
 
 ### Agent Pattern
 
-All four agents follow the same pattern:
+All five agents follow the same pattern:
 1. Validate context/inputs
 2. Get Claude client via `config/auth_config.get_anthropic_client()`
 3. Build a prompt using system prompt from `config/agent_prompts.py` + user context
@@ -62,6 +64,7 @@ All four agents follow the same pattern:
 |-------|------------|-----------|------------|
 | Design | `agents/design_agent.run_design()` | title, description, repo_path | design_analysis, impacted_components, risks, acceptance_criteria |
 | Development | `agents/go_k8s_developer.run_development()` | AgentState dict (needs implementation_plan as list) | code_files, test_files, pr_description |
+| Code Review | `agents/code_review_agent.run_code_review()` | AgentState dict (code_files from development) | review_passed, review_findings, review_summary, review_iteration |
 | Testing | `agents/testing_agent.run_testing()` | context dict (needs design_analysis, impacted_components, acceptance_criteria) | test_plan, unit/integration/e2e_tests, coverage_analysis |
 | Docs | `agents/docs_agent.run_docs()` | context dict + optional input_files, output_format, enable_rag | pr_summary, release_notes, docs_changes |
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ uv run python scripts/test_agents.py --e2e --dry-run --debug
 
 ## Architecture
 
-The system runs four Claude AI agents in a sequential LangGraph pipeline:
+The system runs five Claude AI agents in a sequential LangGraph pipeline:
 
 ```
-Issue → Design Agent → Development Agent → Testing Agent → Docs Agent → Done
+Issue → Design Agent → Development Agent → Code Review Agent → Testing Agent → Docs Agent → Done
+                              ↑                    │ (fail: blocking issues found)
+                              └────────────────────┘ auto-fix loop (≤ MAX_REVIEW_ITER)
 ```
 
 Each agent reads from the shared `AgentState` and writes its outputs back before the next agent begins. Each phase includes automatic output validation — the workflow stops immediately if required outputs are missing, rather than silently passing bad data forward. See [Architecture](docs/user-guide/02-concepts/architecture.md) for a full breakdown.


### PR DESCRIPTION
## Problem
Root `README.md` and `CLAUDE.md` still referenced "four Claude AI agents" after the Code Review Agent was added, causing the reviewer to flag the documentation as inconsistent with the implementation.

## Changes
- **README.md**: "four" → "five" agents; pipeline diagram updated to include Code Review Agent with auto-fix loop annotation
- **CLAUDE.md**: "four" → "five" agents in agent description; Code Review Agent row added to the agent table; LangGraph diagram updated to show `code_review_node` and auto-fix loop

## Tests
383 passed, 6 skipped (real_api marker — require GCP credentials), 0 failed.