### PR TITLE
fix: Add missing JIRA_USER_EMAIL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,8 +174,9 @@ QODO_CLI_PATH=
 # ----------------------------------------------------------------------------
 
 # Jira API Token (for future Jira MCP integration)
-JIRA_API_TOKEN=your-jira-api-token-here
 JIRA_BASE_URL=https://your-org.atlassian.net
+JIRA_USER_EMAIL=your-email@company.com
+JIRA_API_TOKEN=your-jira-api-token-here
 
 # ----------------------------------------------------------------------------
 # Notes


### PR DESCRIPTION
JIRA_USER_EMAIL was missing from the Jira configuration section. Required for Jira REST API authentication alongside JIRA_BASE_URL and JIRA_API_TOKEN.