### PR TITLE
docs: document GitHub PR fetching from Jira remotelinks

### DIFF
--- a/docs/user-guide/01-getting-started/configuration.md
+++ b/docs/user-guide/01-getting-started/configuration.md
@@ -93,6 +93,23 @@ MAX_REPO_FILES=50
 API_TIMEOUT=120
 ```
 
+### GitHub Integration
+
+Required for fetching upstream PR metadata linked to Jira tickets.
+
+| Variable                  | Required | Default | Description                                                                                                   |
+|---------------------------|----------|---------|---------------------------------------------------------------------------------------------------------------|
+| `GITHUB_TOKEN`            | Optional | (none)  | Personal access token for reading GitHub PR data. Without it, PR URLs are shown but metadata is not fetched. |
+| `GITHUB_REQUEST_TIMEOUT`  | Optional | `10`    | Timeout in seconds for GitHub API requests                                                                    |
+
+```bash
+# GitHub Integration (optional — enriches docs agent with upstream PR context)
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+GITHUB_REQUEST_TIMEOUT=10
+```
+
+To create a token: GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens. Required scope: `Contents` (read-only) on the target repositories.
+
 ### Agent Behavior
 
 | Variable | Default | Description |

--- a/docs/user-guide/02-concepts/architecture.md
+++ b/docs/user-guide/02-concepts/architecture.md
@@ -209,6 +209,7 @@ Optional tools in `tools/` that agents can use when a repository path is provide
 - `tools/repo_search.py` - Code search and Go package analysis
 - `tools/rag_search.py` - Documentation search with RAG for the docs agent
 - `tools/git_ops.py` - Git operations and repository utilities
+- `tools/github_client.py` - GitHub REST API client for fetching PR metadata linked to Jira tickets via remote links
 
 ### Configuration
 
@@ -267,7 +268,7 @@ muilti-agents-ocp-builds/
 ├── mcp/             # MCP server stubs (future integrations)
 ├── scripts/         # orchestrate.py, run_dashboard.py, test_agents.py
 ├── tests/           # pytest test suite
-├── tools/           # repo_search, rag_search, git_ops
+├── tools/           # repo_search, rag_search, git_ops, github_client
 └── utils/           # logging_config.py
 ```
 

--- a/docs/user-guide/03-agents/docs-agent.md
+++ b/docs/user-guide/03-agents/docs-agent.md
@@ -40,6 +40,8 @@ To customize Documentation Agent behavior, edit `DOCS_AGENT_PROMPT` in `config/a
 | `issue_description` | str | No | Original issue description |
 | `issue_type` | str | No | `bug`, `feature`, `refactor`, or `docs` |
 | `repo_path` | str | No | Required for RAG - path to repository |
+| `github_pr_urls` | list[str] | No | GitHub PR URLs extracted from Jira remote links |
+| `github_pr_data` | list[dict] | No | Full PR metadata fetched from GitHub API (title, author, reviewers, state, files changed, etc.) |
 
 ### Function Parameters
 
@@ -235,6 +237,67 @@ result = run_docs(context=context, enable_rag=False)
 | Missing required context keys | Raises `RuntimeError: Missing required context keys` |
 
 **Required context keys:** `design_analysis`, `code_changes`, `test_results`
+
+---
+
+## Upstream GitHub PR Integration
+
+When a Jira ticket has GitHub PRs linked via remote links, the docs agent automatically includes them in an "Upstream GitHub Pull Requests" context section that is injected into the prompt before generation.
+
+### What triggers it
+
+The orchestration pipeline fetches Jira remote links and resolves any linked GitHub PRs before calling the docs agent. The resolved data arrives in the context as `github_pr_urls` (a list of URLs) and `github_pr_data` (a list of dicts with full PR metadata). The docs agent detects whichever is present and builds the context section accordingly.
+
+### PR fields included in the prompt
+
+When `github_pr_data` is available (requires `GITHUB_TOKEN` to be set at fetch time), each PR entry includes:
+
+| Field | Description |
+|-------|-------------|
+| PR number and URL | Link back to the upstream pull request |
+| Title | PR title as written by the author |
+| State | `MERGED`, `OPEN`, or `CLOSED` |
+| Author | GitHub username of the PR author |
+| Base branch | Target branch the PR merges into |
+| Files changed | Count of changed files with `+additions / -deletions` |
+| Reviewers | Usernames of requested and completed reviewers |
+| Labels | All labels attached to the PR |
+| Merged at | ISO timestamp of when the PR was merged (if applicable) |
+| Body | PR description, capped at 2,000 characters to control prompt size |
+
+### Graceful fallback behavior
+
+| Situation | Behavior |
+|-----------|----------|
+| `github_pr_data` present | Full metadata injected into prompt |
+| `github_pr_urls` present but no `github_pr_data` | List of PR URLs injected without metadata (no `GITHUB_TOKEN` was available at fetch time) |
+| Neither key present | "Upstream GitHub Pull Requests" section is omitted from the prompt entirely |
+
+### Example output
+
+When GitHub PR data is available, the docs agent uses it to ground the generated documentation in real upstream activity. For example, a PR summary might include:
+
+```markdown
+## PR Summary
+
+This change adds `RuntimeClass` support to Shipwright BuildStrategies, enabling
+pod-level runtime isolation for builds that require specific node capabilities.
+
+**Upstream reference:** Implemented in [shipwright-io/community #42](https://github.com/shipwright-io/community/pull/42)
+— _"Add RuntimeClass support to BuildStrategy pod template"_ (MERGED, authored by @adambkaplan,
+reviewed by @qu1queee and @SaschaSchwarze0).
+
+The upstream PR modified 6 files (+312 / -18 lines) targeting the `main` branch and was
+merged on 2024-11-14. Labels: `enhancement`, `api-change`.
+
+**What changed:**
+- Added `runtimeClassName` field to `BuildStrategySpec.BuildSteps`
+- CRD schema updated to include the new optional field
+- Controller updated to propagate `runtimeClassName` to generated pods
+
+**Testing:** Unit tests cover field propagation. E2E tests verify builds complete
+successfully when a valid `RuntimeClass` is referenced.
+```
 
 ---
 

--- a/docs/user-guide/08-testing/README.md
+++ b/docs/user-guide/08-testing/README.md
@@ -1,6 +1,6 @@
 # Testing
 
-The test suite validates all agents and the orchestration workflow using a dual-mode approach: fast offline testing with mocked responses when no API credentials are present, and full integration testing against the real Claude API when Vertex AI is configured. All 389 tests run under pytest with automatic skip logic so you never need to change commands based on your environment.
+The test suite validates all agents and the orchestration workflow using a dual-mode approach: fast offline testing with mocked responses when no API credentials are present, and full integration testing against the real Claude API when Vertex AI is configured. All 390 tests run under pytest with automatic skip logic so you never need to change commands based on your environment.
 
 ---
 
@@ -8,7 +8,7 @@ The test suite validates all agents and the orchestration workflow using a dual-
 
 | Metric | Value |
 | ------ | ----- |
-| Total tests | 389 |
+| Total tests | 390 |
 | Core test modules | 14 |
 | Mock-mode execution time | Completes in seconds |
 | Real API execution time | Varies (network latency) |
@@ -18,9 +18,9 @@ The test suite validates all agents and the orchestration workflow using a dual-
 
 The suite detects your environment at collection time and adjusts automatically.
 
-**Mock mode** runs when `ANTHROPIC_VERTEX_PROJECT_ID` is not set or the `google-auth` package is not installed. All tests that require a live API are skipped; the remaining 383 tests run entirely offline using fixtures and `unittest.mock` patches. This is the default for local development and CI pipelines without credentials.
+**Mock mode** runs when `ANTHROPIC_VERTEX_PROJECT_ID` is not set or the `google-auth` package is not installed. All tests that require a live API are skipped; the remaining 384 tests run entirely offline using fixtures and `unittest.mock` patches. This is the default for local development and CI pipelines without credentials.
 
-**Real API mode** activates when `ANTHROPIC_VERTEX_PROJECT_ID` is set and `google.auth` is importable. All 389 tests run, including the 6 tests that are auto-skipped in mock mode and make actual calls to Claude via Vertex AI. Use this mode to validate end-to-end integration or catch breaking API changes.
+**Real API mode** activates when `ANTHROPIC_VERTEX_PROJECT_ID` is set and `google.auth` is importable. All 390 tests run, including the 6 tests that are auto-skipped in mock mode and make actual calls to Claude via Vertex AI. Use this mode to validate end-to-end integration or catch breaking API changes.
 
 ---
 
@@ -113,7 +113,7 @@ uv run pytest tests/test_agents_validator_design.py::TestDesignAgent::test_desig
 | File | Tests | What It Covers |
 | ---- | ----- | -------------- |
 | `test_agents_code_review.py` | 90 | Code Review Agent: output parsing, severity classification, auto-fix loop routing, dry-run, validators, mock responses |
-| `test_agents_validator_jira.py` | 67 | Jira ticket fetching, context injection, field parsing, error handling, dry-run mode |
+| `test_agents_validator_jira.py` | 68 | Jira ticket fetching, context injection, field parsing, error handling, dry-run mode |
 | `test_agents_validator_develop.py` | 34 | Development agent code generation, prompt building, output parsing, review feedback injection |
 | `test_agents_validator_orchestration.py` | 29 | Full 5-agent workflow, state management, node execution, graph routing, auto-fix loop |
 | `test_agents_validator_dashboard.py` | 25 | Dashboard heartbeat, enricher pipeline, session storage, REST endpoints |
@@ -322,7 +322,7 @@ When `ANTHROPIC_VERTEX_PROJECT_ID` is not set as a secret, all tests guarded by 
 | Mock patches not applying | Confirm the patch target path matches the import in the module under test (patch where it is used, not where it is defined) |
 | `conftest.py` fixtures not found | Confirm `tests/conftest.py` exists and pytest is invoked from the project root |
 | Vertex AI quota errors | Check GCP console for rate limits; consider running real API tests on a schedule rather than every commit |
-| `383 passed, 6 skipped` result | Expected behavior in mock mode — the 6 skipped tests require `ANTHROPIC_VERTEX_PROJECT_ID` (they use `skipif(not HAS_ANTHROPIC_AUTH)` from `tests/auth_helper.py`) |
+| `384 passed, 6 skipped` result | Expected behavior in mock mode — the 6 skipped tests require `ANTHROPIC_VERTEX_PROJECT_ID` (they use `skipif(not HAS_ANTHROPIC_AUTH)` from `tests/auth_helper.py`) |
 
 ---
 

--- a/docs/user-guide/09-integrations/jira-rovo.md
+++ b/docs/user-guide/09-integrations/jira-rovo.md
@@ -20,6 +20,8 @@ The three required environment variables are:
 | `JIRA_USER_EMAIL` | The email address tied to your API token |
 | `JIRA_API_TOKEN` | Your Atlassian API token |
 
+A `GITHUB_TOKEN` is optional but recommended if your Jira tickets link to GitHub pull requests — see [GitHub PR Integration](#github-pr-integration) below.
+
 ---
 
 ## Configuration
@@ -72,15 +74,17 @@ uv run python scripts/orchestrate.py --jira-ticket SHIP-123 --dry-run
 
 The integration reads the following fields from the Jira REST API v3 and passes them as structured context to the agent pipeline:
 
-| Field | Jira Source | Used by |
-|-------|-------------|---------|
-| Title | Summary | All agents |
-| Description | Description (ADF converted to plain text) | Design agent |
-| Acceptance Criteria | Custom AC field or AC section in description | Design, Testing agents |
-| Priority | Priority field | Design agent |
-| Labels | Labels | All agents |
-| Linked Issues | Issue links | Design agent |
-| Recent Comments | Last 5 comments (summarized) | Design agent |
+| Field | Source | Used by |
+|-------|--------|---------|
+| Title | Jira — Summary | All agents |
+| Description | Jira — Description (ADF converted to plain text) | Design agent |
+| Acceptance Criteria | Jira — Custom AC field or AC section in description | Design, Testing agents |
+| Priority | Jira — Priority field | Design agent |
+| Labels | Jira — Labels | All agents |
+| Linked Issues | Jira — Issue links | Design agent |
+| Recent Comments | Jira — Last 5 comments (summarized) | Design agent |
+| GitHub PR URLs | Remote links API (`/remotelink` endpoint) | Docs agent |
+| GitHub PR Data | GitHub REST API v3 (via `GITHUB_TOKEN`) | Docs agent |
 
 The acceptance criteria are extracted from the Jira custom field if present, or parsed from an "Acceptance Criteria" section in the description body if not. This allows the Testing agent to generate test cases directly from the ticket requirements without any manual copy-paste.
 
@@ -133,6 +137,58 @@ This is equivalent to passing a fixed `--title` and `--description` while still 
 | `JIRA_BASE_URL is not set` | Missing environment variable | Add all three variables to `.env` |
 
 If you receive an authentication error after confirming credentials, regenerate the API token at [https://id.atlassian.com/manage-profile/security](https://id.atlassian.com/manage-profile/security) and update `.env`.
+
+---
+
+## GitHub PR Integration
+
+When a Jira ticket has remote links pointing to GitHub pull requests, the docs agent automatically fetches full PR metadata and includes it in the documentation context. This gives the docs agent access to the actual code changes, review decisions, and merge status — without any manual input.
+
+### How It Works
+
+The pipeline follows four steps to enrich the docs agent with GitHub PR data:
+
+1. **Remote links fetch** — After fetching the Jira ticket, the integration calls `GET /rest/api/3/issue/{id}/remotelink` via the `_fetch_remotelinks()` method. This returns all external URLs attached to the ticket.
+2. **PR URL extraction** — From those remote links, any URL containing both `github.com` and `/pull/` is identified as a GitHub pull request URL.
+3. **GitHub API fetch** — Each PR URL is resolved against the GitHub REST API v3 via `tools/github_client.py`, which retrieves full PR metadata.
+4. **Docs agent context** — The collected PR data is assembled into an "Upstream GitHub Pull Requests" context section and passed to the docs agent alongside the Jira fields.
+
+### What PR Metadata Is Fetched
+
+`tools/github_client.py` retrieves the following for each linked pull request:
+
+| Field | Description |
+|-------|-------------|
+| Title | PR title |
+| Body | PR description, capped at 2000 characters to manage token usage |
+| Author | GitHub username of the PR author |
+| Reviewers | List of requested reviewers and review participants |
+| State | `merged`, `open`, or `closed` |
+| Labels | Labels applied to the PR |
+| Base branch | The branch the PR targets |
+| Head branch | The branch the PR was opened from |
+| Files changed | List of changed files with `+additions` / `-deletions` counts |
+| Created at | Timestamp when the PR was opened |
+| Merged at | Timestamp when the PR was merged (if applicable) |
+
+The PR body cap (2000 characters) prevents large PR descriptions from consuming a disproportionate share of the context window. The remaining fields are always included in full.
+
+### Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | Optional (but recommended) | Personal access token — without it, PR URLs are shown but metadata is not fetched |
+| `GITHUB_REQUEST_TIMEOUT` | Optional | Timeout in seconds for GitHub API calls (default: `10`) |
+
+Without a `GITHUB_TOKEN`, the remote link URLs are still extracted from Jira and logged, but no GitHub API call is made and no PR metadata is added to the docs agent context.
+
+**To create a token:** GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
+
+Required scope: `Contents` (read-only) on the target repositories.
+
+### Dry-Run Behavior
+
+When `--dry-run` is used, no real GitHub API calls are made. Instead, mock PR data is returned from `config/mock_responses.py` (`MOCK_GITHUB_PR`). The mock response follows the same structure as a live response, so the docs agent processes it identically. This lets you test the full pipeline — including the "Upstream GitHub Pull Requests" context section — without a `GITHUB_TOKEN` or network access.
 
 ---
 


### PR DESCRIPTION
Documents the GitHub PR fetching feature implemented in #20. Updates jira-rovo.md, docs-agent.md, configuration.md, architecture.md, and testing README with new counts.