### PR TITLE
chore: update default model from claude-sonnet-4-20250514 to claude-sonnet-4-6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,9 +74,9 @@ LOG_FILE_PATH=
 
 # Claude Model Version
 # Specifies which Claude model version to use for design analysis.
-# Default: claude-sonnet-4-20250514
+# Default: claude-sonnet-4-6
 # Other options: claude-opus-4-20250514, claude-3-5-sonnet-20241022
-CLAUDE_MODEL=claude-sonnet-4-20250514
+CLAUDE_MODEL=claude-sonnet-4-6
 
 # Maximum Tokens for Claude Response
 # Controls the maximum length of Claude's response.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ All five agents follow the same pattern:
 1. Validate context/inputs
 2. Get Claude client via `config/auth_config.get_anthropic_client()`
 3. Build a prompt using system prompt from `config/agent_prompts.py` + user context
-4. Call `client.messages.create()` with the configured model (`CLAUDE_MODEL` env var, default `claude-sonnet-4-20250514`)
+4. Call `client.messages.create()` with the configured model (`CLAUDE_MODEL` env var, default `claude-sonnet-4-6`)
 5. Parse the Markdown-structured response into typed dict outputs
 6. Emit heartbeat to dashboard
 
@@ -99,7 +99,7 @@ Tests are in `tests/` and use pytest. The `conftest.py` provides shared fixtures
 |----------|---------|
 | `ANTHROPIC_VERTEX_PROJECT_ID` | GCP project ID for Vertex AI auth |
 | `CLOUD_ML_REGION` | GCP region (default: `us-east5`) |
-| `CLAUDE_MODEL` | Model override (default: `claude-sonnet-4-20250514`) |
+| `CLAUDE_MODEL` | Model override (default: `claude-sonnet-4-6`) |
 | `CLAUDE_MAX_TOKENS` | Max tokens override |
 | `SHIPWRIGHT_REPO_PATH` / `OPENSHIFT_BUILDS_REPO_PATH` | Repo paths for code analysis |
 | `DASHBOARD_URL` | Dashboard URL (default: `http://localhost:8080`) |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Each agent reads from the shared `AgentState` and writes its outputs back before
 |----------|---------|
 | `ANTHROPIC_VERTEX_PROJECT_ID` | GCP project ID for Vertex AI auth (required) |
 | `CLOUD_ML_REGION` | GCP region (default: `us-east5`) |
-| `CLAUDE_MODEL` | Model override (default: `claude-sonnet-4-20250514`) |
+| `CLAUDE_MODEL` | Model override (default: `claude-sonnet-4-6`) |
 | `DASHBOARD_ENABLED` | Enable heartbeats to dashboard (default: `true`) |
 | `SHIPWRIGHT_REPO_PATH` | Path to Shipwright Build repo for deeper analysis |
 | `MANUAL_APPROVAL` | Pause for user approval between phases (default: `false`) |

--- a/agents/code_review_agent.py
+++ b/agents/code_review_agent.py
@@ -150,7 +150,7 @@ def _run_claude_review(state: dict[str, Any]) -> dict[str, Any]:
         f"End your response with either 'VERDICT: PASS' or 'VERDICT: FAIL'."
     )
 
-    model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+    model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
     response = client.messages.create(
         model=model,
         max_tokens=4000,

--- a/agents/design_agent.py
+++ b/agents/design_agent.py
@@ -96,7 +96,7 @@ def run_design(title: str, description: str, repo_path: Optional[str] = None) ->
 
     # Call Claude API
     try:
-        model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+        model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
         logger.info(f"Calling Claude API with model: {model}")
 
         response = client.messages.create(

--- a/agents/docs_agent.py
+++ b/agents/docs_agent.py
@@ -135,7 +135,7 @@ def run_docs(
 
     try:
         # Call Claude API
-        model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+        model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
         logger.info(f"Calling Claude API with model: {model}, max_tokens: 8192, temperature: 0.3")
         session_logger.info(f"API Request: model={model}, max_tokens=8192, temperature=0.3")
 

--- a/agents/go_k8s_developer.py
+++ b/agents/go_k8s_developer.py
@@ -122,7 +122,7 @@ def run_development(
 
     # Call Claude API
     try:
-        model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+        model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
         logger.info(f"Calling Claude API with model: {model}, max_tokens: 16000")
         session_logger.info(f"API Request: model={model}, max_tokens=16000, temperature=0.2")
 

--- a/agents/testing_agent.py
+++ b/agents/testing_agent.py
@@ -112,7 +112,7 @@ def run_testing(context: Dict[str, Any]) -> Dict[str, Any]:
 
     # Call Claude API
     try:
-        model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+        model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
         logger.info(f"Calling Claude API with model: {model}, max_tokens: 16000")
         session_logger.info(f"API Request: model={model}, max_tokens=16000")
 

--- a/dashboard/enrichers.py
+++ b/dashboard/enrichers.py
@@ -39,7 +39,7 @@ class ModelInfoEnricher(Enricher):
         """
         import os
         # Get model from environment or use default
-        heartbeat["model"] = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+        heartbeat["model"] = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
         return heartbeat
 
 

--- a/docs/user-guide/01-getting-started/configuration.md
+++ b/docs/user-guide/01-getting-started/configuration.md
@@ -36,7 +36,7 @@ See [Vertex AI Setup](../05-authentication/vertex-ai.md) for authentication inst
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CLAUDE_MODEL` | `claude-sonnet-4-20250514` | Claude model version |
+| `CLAUDE_MODEL` | `claude-sonnet-4-6` | Claude model version |
 | `CLAUDE_MAX_TOKENS` | `8000` | Default max tokens per response |
 
 > **Note:** The Development and Testing agents override `CLAUDE_MAX_TOKENS` with 16000 to accommodate larger code generation outputs.
@@ -131,7 +131,7 @@ CLOUD_ML_REGION=us-east5
 SHIPWRIGHT_REPO_PATH=/home/user/git/shipwright-build
 
 # Model settings
-CLAUDE_MODEL=claude-sonnet-4-20250514
+CLAUDE_MODEL=claude-sonnet-4-6
 CLAUDE_MAX_TOKENS=8000
 
 # Dashboard

--- a/docs/user-guide/02-concepts/agents-overview.md
+++ b/docs/user-guide/02-concepts/agents-overview.md
@@ -22,7 +22,7 @@ The Design Agent analyzes a GitHub issue and produces a comprehensive design doc
 - Acceptance criteria
 - Implementation plan
 
-**Claude API settings:** model `claude-sonnet-4-20250514`, 8,000 max tokens, temperature 1.0
+**Claude API settings:** model `claude-sonnet-4-6`, 8,000 max tokens, temperature 1.0
 
 ---
 
@@ -40,7 +40,7 @@ The Development Agent generates production-quality Go code for Kubernetes and Op
 - Security notes
 - New dependency list
 
-**Claude API settings:** model `claude-sonnet-4-20250514`, 16,000 max tokens, temperature 0.2 (lower for deterministic code output)
+**Claude API settings:** model `claude-sonnet-4-6`, 16,000 max tokens, temperature 0.2 (lower for deterministic code output)
 
 ---
 
@@ -75,7 +75,7 @@ The Code Review Agent reviews generated Go code for quality, security, and corre
 - `review_summary` — human-readable verdict
 - `review_iteration` — current loop iteration count
 
-**Claude API settings:** model `claude-sonnet-4-20250514`, 4,000 max tokens, temperature 0.1 (very low for consistent, deterministic review output)
+**Claude API settings:** model `claude-sonnet-4-6`, 4,000 max tokens, temperature 0.1 (very low for consistent, deterministic review output)
 
 **Feature flag:** Set `QODO_REVIEW_ENABLED=false` to skip the review phase entirely (backward compatible).
 
@@ -104,7 +104,7 @@ The Testing Agent generates comprehensive Ginkgo v2 test suites. It detects Ship
 - Ginkgo v2 E2E test code
 - Coverage analysis mapped to acceptance criteria
 
-**Claude API settings:** model `claude-sonnet-4-20250514`, 16,000 max tokens
+**Claude API settings:** model `claude-sonnet-4-6`, 16,000 max tokens
 
 ---
 
@@ -121,7 +121,7 @@ The Documentation Agent generates all documentation artifacts from the combined 
 - `"jtbd"` - Adds Jobs-to-be-Done user documentation
 - `"all"` - All formats plus a high-level design document
 
-**Claude API settings:** model `claude-sonnet-4-20250514`, 8,192 max tokens, temperature 0.3 (lower for consistent documentation style)
+**Claude API settings:** model `claude-sonnet-4-6`, 8,192 max tokens, temperature 0.3 (lower for consistent documentation style)
 
 ---
 

--- a/docs/user-guide/03-agents/design-agent.md
+++ b/docs/user-guide/03-agents/design-agent.md
@@ -65,7 +65,7 @@ The `design_analysis` field is a structured Markdown document containing:
 
 | Setting | Value |
 |---------|-------|
-| Model | `claude-sonnet-4-20250514` |
+| Model | `claude-sonnet-4-6` |
 | Max tokens | 8,000 |
 | Temperature | 1.0 (default) |
 

--- a/docs/user-guide/03-agents/development-agent.md
+++ b/docs/user-guide/03-agents/development-agent.md
@@ -59,7 +59,7 @@ The agent reads from a context dictionary, which is populated from `AgentState` 
 
 | Setting | Value |
 |---------|-------|
-| Model | `claude-sonnet-4-20250514` |
+| Model | `claude-sonnet-4-6` |
 | Max tokens | 16,000 (larger for code generation) |
 | Temperature | 0.2 (lower for deterministic code output) |
 

--- a/docs/user-guide/03-agents/docs-agent.md
+++ b/docs/user-guide/03-agents/docs-agent.md
@@ -93,7 +93,7 @@ To customize Documentation Agent behavior, edit `DOCS_AGENT_PROMPT` in `config/a
 
 | Setting | Value |
 |---------|-------|
-| Model | `claude-sonnet-4-20250514` |
+| Model | `claude-sonnet-4-6` |
 | Max tokens | 8,192 |
 | Temperature | 0.3 (lower for consistent documentation style) |
 

--- a/docs/user-guide/03-agents/testing-agent.md
+++ b/docs/user-guide/03-agents/testing-agent.md
@@ -58,7 +58,7 @@ To customize Testing Agent behavior, edit `TESTING_AGENT_PROMPT` in `config/agen
 
 | Setting | Value |
 |---------|-------|
-| Model | `claude-sonnet-4-20250514` |
+| Model | `claude-sonnet-4-6` |
 | Max tokens | 16,000 (larger for test code generation) |
 
 ---

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -104,7 +104,7 @@ This system automates the design, development, testing, and documentation workfl
 
 | Item | Value |
 |------|-------|
-| Default model | `claude-sonnet-4-20250514` |
+| Default model | `claude-sonnet-4-6` |
 | Python requirement | 3.11 or higher |
 | Auth method | Google Vertex AI (Application Default Credentials) |
 | Dashboard port | 8080 (local only) |

--- a/examples/auth_example.py
+++ b/examples/auth_example.py
@@ -40,7 +40,7 @@ def main():
         # Uncomment to test (will use API credits):
         # print("\n3. Testing client with a simple API call...")
         # response = client.messages.create(
-        #     model="claude-sonnet-4-20250514",
+        #     model="claude-sonnet-4-6",
         #     max_tokens=100,
         #     messages=[{"role": "user", "content": "Say hello!"}]
         # )

--- a/tests/test_agents_validator_design.py
+++ b/tests/test_agents_validator_design.py
@@ -140,7 +140,7 @@ class TestDesignAgent:
                 call_args = mock_client.messages.create.call_args
 
                 # Validate request structure
-                expected_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+                expected_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
                 assert call_args.kwargs["model"] == expected_model
                 assert call_args.kwargs["max_tokens"] == 8000
                 assert len(call_args.kwargs["messages"]) == 1

--- a/tests/test_agents_validator_develop.py
+++ b/tests/test_agents_validator_develop.py
@@ -458,7 +458,7 @@ class TestDevelopmentAgent:
                 call_args = mock_client.messages.create.call_args
 
                 # Validate request structure
-                expected_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+                expected_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
                 assert call_args.kwargs["model"] == expected_model
                 assert call_args.kwargs["max_tokens"] == 16000
                 assert call_args.kwargs["temperature"] == 0.2

--- a/tests/test_agents_validator_docs.py
+++ b/tests/test_agents_validator_docs.py
@@ -236,7 +236,7 @@ class TestDocsAgent:
                 call_args = mock_client.messages.create.call_args
 
                 # Validate request structure
-                expected_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+                expected_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
                 assert call_args.kwargs["model"] == expected_model
                 assert call_args.kwargs["max_tokens"] == 8192  # Increased for enhanced features
                 assert call_args.kwargs["temperature"] == 0.3

--- a/tests/test_agents_validator_testing.py
+++ b/tests/test_agents_validator_testing.py
@@ -344,7 +344,7 @@ class TestTestingAgent:
                 call_args = mock_client.messages.create.call_args
 
                 # Validate request structure
-                expected_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+                expected_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
                 assert call_args.kwargs["model"] == expected_model
                 assert call_args.kwargs["max_tokens"] == 16000
                 assert len(call_args.kwargs["messages"]) == 1


### PR DESCRIPTION
Updates the default Claude model identifier across all agent files, tests, dashboard, docs, and config files from the deprecated `claude-sonnet-4-20250514` format to the new `claude-sonnet-4-6` model ID.