### PR TITLE
fix: correct doctest examples in testing_agent, auth_config, and logging_config

### DIFF
--- a/agents/testing_agent.py
+++ b/agents/testing_agent.py
@@ -66,8 +66,8 @@ def run_testing(context: Dict[str, Any]) -> Dict[str, Any]:
         ...     "issue_title": "Add timeout support",
         ...     "issue_description": "Users need build timeout...",
         ... }
-        >>> result = run_testing(context)
-        >>> print(result["test_plan"])
+        >>> result = run_testing(context)  # doctest: +SKIP
+        >>> print(result["test_plan"])  # doctest: +SKIP
     """
     # Get session-specific logger
     session_id = context.get("session_id", "unknown")

--- a/config/auth_config.py
+++ b/config/auth_config.py
@@ -114,7 +114,8 @@ def validate_authentication() -> dict:
 
     Example:
         >>> auth_info = validate_authentication()
-        >>> print(f"Authentication type: {auth_info['auth_type']}")
+        >>> print(f"Authentication type: {auth_info['auth_type']}")  # doctest: +ELLIPSIS
+        Authentication type: ...
     """
     use_vertex = os.getenv("CLAUDE_CODE_USE_VERTEX") == "1"
     vertex_project_id = os.getenv("ANTHROPIC_VERTEX_PROJECT_ID")

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -52,9 +52,9 @@ def setup_logging(
         Configured logger instance
 
     Example:
-        >>> logger = setup_logging(debug=True, log_file=Path("/tmp/test.log"))
-        >>> logger.debug("This is a debug message")
-        >>> logger.info("This is an info message")
+        >>> logger = setup_logging(debug=True, log_file=Path("/tmp/test.log"))  # doctest: +SKIP
+        >>> logger.debug("This is a debug message")  # doctest: +SKIP
+        >>> logger.info("This is an info message")  # doctest: +SKIP
     """
     # Determine log level
     log_level = logging.DEBUG if debug else logging.INFO


### PR DESCRIPTION
Fixes malformed doctest examples that would fail under `python -m doctest` or `pytest --doctest-modules`:

- `agents/testing_agent.py`: Added `# doctest: +SKIP` to lines calling real Claude API
- `config/auth_config.py`: Added `# doctest: +ELLIPSIS` and expected output line for print statement
- `utils/logging_config.py`: Added `# doctest: +SKIP` to lines that emit log output as a side effect

No logic changes — docstring examples only.