### PR TITLE
fix(jira): improve error handling when Jira returns non-JSON response

### DIFF
--- a/tests/test_agents_validator_jira.py
+++ b/tests/test_agents_validator_jira.py
@@ -377,6 +377,31 @@ class TestFetchTicket:
         joined = " ".join(result["acceptance_criteria"])
         assert "timeout" in joined.lower()
 
+    def test_fetch_ticket_raises_value_error_on_non_json_content_type(self, client):
+        """fetch_ticket should raise ValueError with a clear message when Jira returns HTML."""
+        html_response = MagicMock()
+        html_response.status_code = 200
+        html_response.raise_for_status = MagicMock()
+        html_response.headers = {"Content-Type": "text/html; charset=utf-8"}
+        html_response.text = "<html><body>Login required</body></html>"
+
+        with patch("requests.get", return_value=html_response):
+            with pytest.raises(ValueError, match="non-JSON response"):
+                client.fetch_ticket("SHIP-HTML")
+
+    def test_fetch_ticket_raises_value_error_on_json_decode_error(self, client):
+        """fetch_ticket should raise ValueError with a clear message on malformed JSON."""
+        bad_json_response = MagicMock()
+        bad_json_response.status_code = 200
+        bad_json_response.raise_for_status = MagicMock()
+        bad_json_response.headers = {"Content-Type": "application/json"}
+        bad_json_response.text = "<not-json>"
+        bad_json_response.json.side_effect = json.JSONDecodeError("Expecting value", "<not-json>", 0)
+
+        with patch("requests.get", return_value=bad_json_response):
+            with pytest.raises(ValueError, match="invalid JSON"):
+                client.fetch_ticket("SHIP-BADJSON")
+
     def test_fetch_ticket_extracts_github_pr_urls(self, client):
         """fetch_ticket returns GitHub PR URLs from remotelinks."""
         api_response = {

--- a/tools/jira_client.py
+++ b/tools/jira_client.py
@@ -6,6 +6,7 @@ No Forge or Rovo required — standard REST API access.
 Auth: Base64(email:api_token) via JIRA_USER_EMAIL + JIRA_API_TOKEN env vars.
 """
 
+import json
 import os
 import base64
 import logging
@@ -55,7 +56,31 @@ class JiraClient:
         response = requests.get(url, headers=self.headers, params=params, timeout=JIRA_REQUEST_TIMEOUT)
         response.raise_for_status()
 
-        data = response.json()
+        content_type = response.headers.get("Content-Type", "")
+        if "application/json" not in content_type:
+            snippet = response.text[:300]
+            logger.warning(
+                "Jira returned non-JSON response (status=%s, content-type=%s): %s",
+                response.status_code, content_type, snippet
+            )
+            raise ValueError(
+                f"Jira API returned non-JSON response (status={response.status_code}). "
+                "Check JIRA_BASE_URL, JIRA_USER_EMAIL, and JIRA_API_TOKEN env vars."
+            )
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError as exc:
+            snippet = response.text[:300]
+            logger.warning(
+                "Jira returned invalid JSON (status=%s, content-type=%s): %s",
+                response.status_code, content_type, snippet
+            )
+            raise ValueError(
+                f"Jira API returned invalid JSON (status={response.status_code}). "
+                "Check JIRA_BASE_URL, JIRA_USER_EMAIL, and JIRA_API_TOKEN env vars."
+            ) from exc
+
         fields = data.get("fields", {})
 
         # Fetch comments separately for cleaner parsing


### PR DESCRIPTION
## Problem
When Jira returns an HTML page (auth failure, login redirect), `fetch_ticket()` threw a cryptic `JSONDecodeError: Expecting value: line 2 column 2` with no hint about the root cause.

## Fix
- Added Content-Type check after `raise_for_status()` — if response is not `application/json`, logs the first 300 chars and raises `ValueError` with a clear message pointing to the env vars
- Wrapped `response.json()` in `json.JSONDecodeError` catch with the same diagnostic pattern
- Added 2 new unit tests covering both failure paths

## Tests
70 tests passing.