### PR TITLE
feat(docs): include JTBD documentation in standard output format

### DIFF
--- a/agents/docs_agent.py
+++ b/agents/docs_agent.py
@@ -531,7 +531,7 @@ def _get_generation_request(output_format: str) -> str:
     )
 
     if output_format == "standard":
-        return base_request + "\nFormat your response with clear section headers."
+        return base_request + jtbd_request + "\nFormat your response with clear section headers."
 
     elif output_format == "jtbd":
         return base_request + jtbd_request + "\nFormat your response with clear section headers."
@@ -582,7 +582,7 @@ def _parse_docs_response(response_text: str, output_format: str) -> Dict[str, An
     output["high_level_design"] = sections.get("high-level design", sections.get("high level design", "")).strip()
 
     # Format-specific sections
-    if output_format in ("jtbd", "all"):
+    if output_format in ("standard", "jtbd", "all"):
         output["jtbd_documentation"] = sections.get("jtbd documentation", "").strip()
 
     if output_format in ("ship", "all"):


### PR DESCRIPTION
## Summary

- `_get_generation_request()`: the `"standard"` branch now appends `jtbd_request` to the prompt, matching what `"jtbd"` already does
- `_parse_docs_response()`: condition extended from `("jtbd", "all")` to `("standard", "jtbd", "all")` so the JTBD Documentation section is parsed when using the default format
- The named `"jtbd"` format is retained unchanged for backwards compatibility

## Test plan

- [x] `uv run pytest tests/test_agents_validator_docs.py -v` — 22 passed, 1 skipped (mock test skipped because real Vertex AI auth is present in this environment)