### PR TITLE
docs: update output format table to reflect JTBD included in standard format

### DIFF
--- a/docs/user-guide/03-agents/docs-agent.md
+++ b/docs/user-guide/03-agents/docs-agent.md
@@ -57,9 +57,9 @@ To customize Documentation Agent behavior, edit `DOCS_AGENT_PROMPT` in `config/a
 
 | Format | Description |
 |--------|-------------|
-| `"standard"` | PR summary, release notes, upgrade notes, known limitations |
+| `"standard"` | PR summary, release notes, upgrade notes, known limitations, and JTBD documentation |
 | `"ship"` | Adds a SHIP (Solution, Highlight, Impact, Plan) document |
-| `"jtbd"` | Adds Jobs-to-be-Done user documentation |
+| `"jtbd"` | Same as `"standard"` — included for backwards compatibility |
 | `"all"` | All formats plus a high-level design document |
 
 ---
@@ -77,8 +77,8 @@ To customize Documentation Agent behavior, edit `DOCS_AGENT_PROMPT` in `config/a
     "high_level_design": str,        # High-level design summary
 
     # Format-specific outputs
-    "jtbd_documentation": str,       # Jobs-to-be-Done (if requested)
-    "ship_document": str,            # SHIP format (if requested)
+    "jtbd_documentation": str,       # Jobs-to-be-Done (always included for standard and jtbd; also for all)
+    "ship_document": str,            # SHIP format (if ship or all requested)
 
     # Metadata
     "input_files_analyzed": list,    # Files that were read and included


### PR DESCRIPTION
## Summary

- Updates the Output Formats table in `docs/user-guide/03-agents/docs-agent.md` to reflect that `standard` now produces `jtbd_documentation` by default
- Notes `jtbd` format as equivalent to `standard` for backwards compatibility
- Updates the inline comment in the Outputs code block to match the new behaviour

## Test plan

- [ ] Verify the Output Formats table accurately reflects `agents/docs_agent.py` `_get_generation_request()` and `_parse_docs_response()` logic
- [ ] Confirm no other documentation files reference the old `standard`-does-not-include-JTBD behaviour