### PR TITLE
feat(testing): add test_plan.md and Go test files as output artifacts

### DIFF
--- a/agents/testing_agent.py
+++ b/agents/testing_agent.py
@@ -448,7 +448,9 @@ def _extract_test_code(section_text: str) -> Dict[str, str]:
         section_text: Section text containing test code
 
     Returns:
-        Dictionary mapping file names to code content
+        Dictionary mapping full relative file paths to code content.
+        Keys are full paths like ``pkg/reconciler/buildrun/resources/step_test.go``
+        rather than bare basenames.
     """
     tests = {}
 
@@ -459,16 +461,29 @@ def _extract_test_code(section_text: str) -> Dict[str, str]:
     in_code_block = False
 
     for line in lines:
-        # Check for file path indicators
-        if "file:" in line.lower() or "_test.go" in line:
-            # Extract file path
+        # Check for file path indicators outside of code blocks.
+        # Patterns handled:
+        #   ### File: `pkg/some/path_test.go`
+        #   ### File: pkg/some/path_test.go
+        #   File: `path_test.go`
+        #   File: path_test.go
+        #   plain lines that contain _test.go
+        if not in_code_block and ("file:" in line.lower() or "_test.go" in line):
             if "_test.go" in line:
-                # Try to extract the file path
-                parts = line.split("_test.go")
-                if parts:
-                    potential_path = parts[0].strip().strip("`").strip("*").strip()
-                    if potential_path:
-                        current_file = potential_path + "_test.go"
+                # Strip markdown/heading prefix and whitespace
+                stripped = line.strip()
+                # Remove heading markers (###, ##, #)
+                while stripped.startswith("#"):
+                    stripped = stripped.lstrip("#").strip()
+                # Remove "File:" or "file:" prefix
+                if "file:" in stripped.lower():
+                    colon_idx = stripped.lower().index("file:")
+                    stripped = stripped[colon_idx + len("file:"):].strip()
+                # Remove surrounding backticks, asterisks, and extra whitespace
+                stripped = stripped.strip("`").strip("*").strip()
+                # Accept the path only when it actually ends with _test.go
+                if stripped.endswith("_test.go") and stripped:
+                    current_file = stripped
 
         # Handle code blocks
         if line.strip().startswith("```"):

--- a/docs/user-guide/03-agents/testing-agent.md
+++ b/docs/user-guide/03-agents/testing-agent.md
@@ -285,6 +285,71 @@ shipwright-build/
 
 ---
 
+## Output Artifacts
+
+When the testing agent runs via `scripts/test_agents.py`, three artifacts are written to the output directory (default `/tmp/claude/agent-tests/`):
+
+| Artifact | Description |
+|----------|-------------|
+| `testing_output.json` | Full structured output from the agent as a JSON file |
+| `test_plan.md` | Human-readable test plan with strategy, scenario counts, and coverage analysis |
+| `go_tests/<full_path>` | Individual Go test files under a `go_tests/` subdirectory, preserving the full relative path (e.g. `go_tests/pkg/reconciler/buildrun/resources/step_test.go`) |
+
+### test_plan.md structure
+
+```markdown
+# Test Plan: <issue title>
+
+## Test Strategy
+<agent's test_plan text>
+
+## Test Coverage by Level
+
+### Unit Tests (N scenarios)
+- **BUILD-XXX-001**: <description>
+  - File: `<path>`
+  - Expected: <expected_outcome>
+
+### Integration Tests (N scenarios)
+...
+
+### E2E Tests (N scenarios)
+...
+
+## Generated Test Files
+- `go_tests/pkg/webhook/validation/buildrun_timeout_test.go`
+- `go_tests/test/integration/buildrun_timeout_test.go`
+- `go_tests/test/e2e/buildrun_timeout_test.go`
+
+## Coverage Analysis
+<agent's coverage_analysis text>
+
+## Detected Patterns
+- Strategies: ['kaniko']
+- Source types: ['git']
+- Output types: ['image']
+```
+
+### go_tests/ directory
+
+Go test files are written with their full relative path preserved so they can be copied directly into a Shipwright repository checkout:
+
+```
+output_dir/
+└── go_tests/
+    ├── pkg/
+    │   └── webhook/
+    │       └── validation/
+    │           └── buildrun_timeout_test.go
+    └── test/
+        ├── integration/
+        │   └── buildrun_timeout_test.go
+        └── e2e/
+            └── buildrun_timeout_test.go
+```
+
+---
+
 ## Best Practices for Better Output
 
 **Provide specific acceptance criteria:**

--- a/scripts/test_agents.py
+++ b/scripts/test_agents.py
@@ -245,6 +245,8 @@ class AgentTester:
 
             log_agent_complete(logger, "testing", output)
             self._save_artifact("testing_output.json", output)
+            self._write_test_plan_md(output)
+            self._write_go_test_files(output)
 
             return output
 
@@ -528,6 +530,133 @@ class AgentTester:
         self._save_artifact("dashboard_test_results.json", results)
 
         return results
+
+    def _write_test_plan_md(self, output: Dict[str, Any]) -> None:
+        """Write a human-readable test plan to test_plan.md in the output directory.
+
+        Args:
+            output: Testing agent output dictionary
+        """
+        try:
+            issue_title = output.get("issue_title") or "Feature"
+
+            # Collect scenarios by type from test_specifications
+            specs = output.get("test_specifications", {})
+            unit_scenarios: list = []
+            integration_scenarios: list = []
+            e2e_scenarios: list = []
+
+            # test_specifications may be a dict with spec IDs as keys
+            # or a dict with a top-level "scenarios" list (parsed YAML).
+            if isinstance(specs, dict):
+                raw_scenarios = specs.get("scenarios")
+                if isinstance(raw_scenarios, list):
+                    # Parsed YAML format: {"scenarios": [...]}
+                    for s in raw_scenarios:
+                        t = s.get("type", "")
+                        if t == "unit":
+                            unit_scenarios.append(s)
+                        elif t == "integration":
+                            integration_scenarios.append(s)
+                        elif t == "e2e":
+                            e2e_scenarios.append(s)
+                else:
+                    # Flat dict format: {id: {type, ...}, ...}
+                    for spec_id, spec in specs.items():
+                        if not isinstance(spec, dict):
+                            continue
+                        t = spec.get("type", "")
+                        entry = {"id": spec_id, **spec}
+                        if t == "unit":
+                            unit_scenarios.append(entry)
+                        elif t == "integration":
+                            integration_scenarios.append(entry)
+                        elif t == "e2e":
+                            e2e_scenarios.append(entry)
+
+            def _format_scenarios(scenarios: list) -> str:
+                if not scenarios:
+                    return "_No scenarios detected._\n"
+                lines = []
+                for s in scenarios:
+                    sid = s.get("id", "")
+                    desc = s.get("description", "")
+                    file_ = s.get("file", "")
+                    outcome = s.get("expected_outcome", "")
+                    lines.append(f"- **{sid}**: {desc}")
+                    if file_:
+                        lines.append(f"  - File: `{file_}`")
+                    if outcome:
+                        lines.append(f"  - Expected: {outcome}")
+                return "\n".join(lines) + "\n"
+
+            # Collect generated file paths
+            all_test_files: list = []
+            for section in ("unit_tests", "integration_tests", "e2e_tests"):
+                for path in output.get(section, {}).keys():
+                    all_test_files.append(f"- `go_tests/{path}`")
+
+            # Patterns
+            patterns = output.get("patterns_detected", {})
+            strategies = patterns.get("strategies", [])
+            source_types = patterns.get("source_types", [])
+            output_types = patterns.get("output_types", [])
+
+            lines = [
+                f"# Test Plan: {issue_title}",
+                "",
+                "## Test Strategy",
+                output.get("test_plan", ""),
+                "",
+                "## Test Coverage by Level",
+                "",
+                f"### Unit Tests ({len(unit_scenarios)} scenarios)",
+                _format_scenarios(unit_scenarios),
+                f"### Integration Tests ({len(integration_scenarios)} scenarios)",
+                _format_scenarios(integration_scenarios),
+                f"### E2E Tests ({len(e2e_scenarios)} scenarios)",
+                _format_scenarios(e2e_scenarios),
+                "## Generated Test Files",
+                "\n".join(all_test_files) if all_test_files else "_No test files generated._",
+                "",
+                "## Coverage Analysis",
+                output.get("coverage_analysis", ""),
+                "",
+                "## Detected Patterns",
+                f"- Strategies: {strategies}",
+                f"- Source types: {source_types}",
+                f"- Output types: {output_types}",
+            ]
+
+            md_path = self.output_dir / "test_plan.md"
+            md_path.write_text("\n".join(lines), encoding="utf-8")
+            self.logger.info(f"Wrote test plan: {md_path}")
+        except Exception as e:
+            self.logger.error(f"Failed to write test_plan.md: {e}")
+
+    def _write_go_test_files(self, output: Dict[str, Any]) -> None:
+        """Write individual Go test files to go_tests/ under the output directory.
+
+        Args:
+            output: Testing agent output dictionary containing unit_tests,
+                    integration_tests, and e2e_tests dicts mapping full_path -> code.
+        """
+        go_tests_dir = self.output_dir / "go_tests"
+        sections = {
+            "unit_tests": output.get("unit_tests", {}),
+            "integration_tests": output.get("integration_tests", {}),
+            "e2e_tests": output.get("e2e_tests", {}),
+        }
+        for section_name, files in sections.items():
+            if not isinstance(files, dict):
+                continue
+            for full_path, code in files.items():
+                if not code:
+                    continue
+                dest = go_tests_dir / full_path
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_text(code, encoding="utf-8")
+                self.logger.info(f"Wrote Go test file: {dest}")
 
     def _save_artifact(self, filename: str, data: Any):
         """Save artifact to output directory.

--- a/tests/test_agents_validator_testing.py
+++ b/tests/test_agents_validator_testing.py
@@ -6,6 +6,7 @@ for Shipwright Build features based on design analysis and acceptance criteria.
 
 import os
 import pytest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from tests.auth_helper import HAS_ANTHROPIC_AUTH
@@ -584,6 +585,101 @@ class TestEdgeCases:
             with patch.dict(os.environ, {"ANTHROPIC_VERTEX_PROJECT_ID": "test-project-id"}):
                 with pytest.raises(TestingAgentError, match="Failed to initialize"):
                     run_testing(SAMPLE_CONTEXT)
+
+
+class TestAgentTesterArtifacts:
+    """Tests for artifact writing methods added to AgentTester."""
+
+    def _make_tester(self, tmp_path: Path):
+        """Return an AgentTester in dry-run mode using tmp_path as output_dir."""
+        from scripts.test_agents import AgentTester
+
+        return AgentTester(dry_run=True, debug=False, output_dir=tmp_path)
+
+    def test_go_test_files_written(self, tmp_path: Path):
+        """After test_testing_agent() runs in mock mode, go_tests/ contains .go files."""
+        tester = self._make_tester(tmp_path)
+        tester.test_testing_agent()
+
+        go_tests_dir = tmp_path / "go_tests"
+        assert go_tests_dir.exists(), "go_tests/ directory was not created"
+
+        go_files = list(go_tests_dir.rglob("*.go"))
+        assert len(go_files) > 0, "No .go files were written under go_tests/"
+
+    def test_plan_md_written(self, tmp_path: Path):
+        """After test_testing_agent() runs in mock mode, test_plan.md exists with expected sections."""
+        tester = self._make_tester(tmp_path)
+        tester.test_testing_agent()
+
+        md_path = tmp_path / "test_plan.md"
+        assert md_path.exists(), "test_plan.md was not created"
+
+        content = md_path.read_text(encoding="utf-8")
+        assert "# Test Plan:" in content
+        assert "## Test Strategy" in content
+        assert "## Test Coverage by Level" in content
+        assert "## Generated Test Files" in content
+        assert "## Coverage Analysis" in content
+        assert "## Detected Patterns" in content
+
+    def test_go_test_files_skips_empty_code(self, tmp_path: Path):
+        """_write_go_test_files() skips entries with empty code strings."""
+        from scripts.test_agents import AgentTester
+
+        tester = AgentTester(dry_run=True, debug=False, output_dir=tmp_path)
+        output = {
+            "unit_tests": {"pkg/foo/foo_test.go": "", "pkg/bar/bar_test.go": "package bar_test"},
+            "integration_tests": {},
+            "e2e_tests": {},
+        }
+        tester._write_go_test_files(output)
+
+        go_tests_dir = tmp_path / "go_tests"
+        assert not (go_tests_dir / "pkg/foo/foo_test.go").exists(), \
+            "Empty code file should not be written"
+        assert (go_tests_dir / "pkg/bar/bar_test.go").exists(), \
+            "Non-empty code file should be written"
+
+    def test_write_test_plan_md_content(self, tmp_path: Path):
+        """_write_test_plan_md() writes correct content for a known output dict."""
+        from scripts.test_agents import AgentTester
+
+        tester = AgentTester(dry_run=True, debug=False, output_dir=tmp_path)
+        output = {
+            "issue_title": "My Feature",
+            "test_plan": "Test everything carefully.",
+            "test_specifications": {
+                "scenarios": [
+                    {
+                        "id": "BUILD-001",
+                        "description": "Validate field",
+                        "type": "unit",
+                        "file": "pkg/api/api_test.go",
+                        "expected_outcome": "No error",
+                    }
+                ]
+            },
+            "unit_tests": {"pkg/api/api_test.go": "package api_test"},
+            "integration_tests": {},
+            "e2e_tests": {},
+            "coverage_analysis": "100% covered.",
+            "patterns_detected": {
+                "strategies": ["kaniko"],
+                "source_types": ["git"],
+                "output_types": ["image"],
+            },
+        }
+        tester._write_test_plan_md(output)
+
+        content = (tmp_path / "test_plan.md").read_text(encoding="utf-8")
+        assert "# Test Plan: My Feature" in content
+        assert "Test everything carefully." in content
+        assert "### Unit Tests (1 scenarios)" in content
+        assert "**BUILD-001**" in content
+        assert "go_tests/pkg/api/api_test.go" in content
+        assert "100% covered." in content
+        assert "kaniko" in content
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fix `_extract_test_code()` in `agents/testing_agent.py` to extract full relative paths (e.g. `pkg/reconciler/buildrun/resources/step_test.go`) as dictionary keys instead of bare basenames. The fix handles `File:` prefixes with or without backticks, heading markers, and leading/trailing whitespace.
- Add `AgentTester._write_test_plan_md()` to `scripts/test_agents.py`: writes `test_plan.md` to the output directory with test strategy, scenario counts per level (unit/integration/e2e), generated file listing, coverage analysis, and detected patterns.
- Add `AgentTester._write_go_test_files()` to `scripts/test_agents.py`: writes each Go test file from `unit_tests`, `integration_tests`, and `e2e_tests` under `go_tests/<full_path>` in the output directory, creating parent directories as needed and skipping empty code strings.
- Wire both writers after `_save_artifact("testing_output.json", output)` in `test_testing_agent()`.
- Add `TestAgentTesterArtifacts` test class in `tests/test_agents_validator_testing.py` with four tests: go files written, test_plan.md written and contains expected headers, empty code skipping, and content correctness for the MD writer.
- Update `docs/user-guide/03-agents/testing-agent.md` with an Output Artifacts section describing all three artifact types and their structure.

## Test plan

- [x] `uv run pytest tests/test_agents_validator_testing.py -v` — 22 passed, 1 skipped (auth-gated real API test skipped in CI)
- [x] All four new `TestAgentTesterArtifacts` tests pass
- [x] All pre-existing tests continue to pass