### PR TITLE
feat: move testing artifact writing into run_testing() for pipeline-mode support

### DIFF
--- a/agents/testing_agent.py
+++ b/agents/testing_agent.py
@@ -8,6 +8,7 @@ output types), and generates structured test plans along with working Ginkgo v2 
 """
 
 import os
+from pathlib import Path
 from typing import Dict, Any, List, Optional
 
 import yaml
@@ -27,7 +28,7 @@ class TestingAgentError(Exception):
     """Base exception for Testing Agent errors."""
 
 
-def run_testing(context: Dict[str, Any]) -> Dict[str, Any]:
+def run_testing(context: Dict[str, Any], output_dir: Optional[Path] = None) -> Dict[str, Any]:
     """Generate Ginkgo tests for Shipwright features.
 
     This function analyzes design documents and generates comprehensive test suites
@@ -150,7 +151,7 @@ def run_testing(context: Dict[str, Any]) -> Dict[str, Any]:
     logger.info(f"Test generation completed: {unit_count} unit, {integration_count} integration, {e2e_count} e2e tests")
     session_logger.info(f"Generated {total_count} test files (unit: {unit_count}, integration: {integration_count}, e2e: {e2e_count})")
 
-    return {
+    result = {
         "test_plan": parsed_result.get("test_plan", ""),
         "test_specifications": parsed_result.get("test_specifications", {}),
         "unit_tests": parsed_result.get("unit_tests", {}),
@@ -161,6 +162,12 @@ def run_testing(context: Dict[str, Any]) -> Dict[str, Any]:
         "patterns_detected": patterns_detected,
         "raw_output": test_output,  # Include raw output for debugging
     }
+
+    # Resolve output directory and write artifacts
+    resolved_output_dir = output_dir if output_dir is not None else Path("/tmp/claude/testing-artifacts")
+    _write_artifacts(result, resolved_output_dir)
+
+    return result
 
 
 def _validate_context(context: Dict[str, Any]) -> None:
@@ -569,3 +576,123 @@ def generate_test_summary(test_results: Dict[str, Any]) -> str:
         summary_lines.append(f"{test_results['coverage_analysis']}\n")
 
     return "".join(summary_lines)
+
+
+def _write_artifacts(output: Dict[str, Any], output_dir: Path) -> None:
+    """Write test_plan.md and go_tests/ files to output_dir."""
+    _write_test_plan_md(output, output_dir)
+    _write_go_test_files(output, output_dir)
+
+
+def _write_test_plan_md(output: Dict[str, Any], output_dir: Path) -> None:
+    """Write a human-readable test plan to test_plan.md."""
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        issue_title = output.get("issue_title") or "Feature"
+
+        specs = output.get("test_specifications", {})
+        unit_scenarios: list = []
+        integration_scenarios: list = []
+        e2e_scenarios: list = []
+
+        if isinstance(specs, dict):
+            raw_scenarios = specs.get("scenarios")
+            if isinstance(raw_scenarios, list):
+                for s in raw_scenarios:
+                    t = s.get("type", "")
+                    if t == "unit":
+                        unit_scenarios.append(s)
+                    elif t == "integration":
+                        integration_scenarios.append(s)
+                    elif t == "e2e":
+                        e2e_scenarios.append(s)
+            else:
+                for spec_id, spec in specs.items():
+                    if not isinstance(spec, dict):
+                        continue
+                    t = spec.get("type", "")
+                    entry = {"id": spec_id, **spec}
+                    if t == "unit":
+                        unit_scenarios.append(entry)
+                    elif t == "integration":
+                        integration_scenarios.append(entry)
+                    elif t == "e2e":
+                        e2e_scenarios.append(entry)
+
+        def _format_scenarios(scenarios: list) -> str:
+            if not scenarios:
+                return "_No scenarios detected._\n"
+            lines = []
+            for s in scenarios:
+                sid = s.get("id", "")
+                desc = s.get("description", "")
+                file_ = s.get("file", "")
+                outcome = s.get("expected_outcome", "")
+                lines.append(f"- **{sid}**: {desc}")
+                if file_:
+                    lines.append(f"  - File: `{file_}`")
+                if outcome:
+                    lines.append(f"  - Expected: {outcome}")
+            return "\n".join(lines) + "\n"
+
+        all_test_files: list = []
+        for section in ("unit_tests", "integration_tests", "e2e_tests"):
+            for path in output.get(section, {}).keys():
+                all_test_files.append(f"- `go_tests/{path}`")
+
+        patterns = output.get("patterns_detected", {})
+        strategies = patterns.get("strategies", [])
+        source_types = patterns.get("source_types", [])
+        output_types = patterns.get("output_types", [])
+
+        lines = [
+            f"# Test Plan: {issue_title}",
+            "",
+            "## Test Strategy",
+            output.get("test_plan", ""),
+            "",
+            "## Test Coverage by Level",
+            "",
+            f"### Unit Tests ({len(unit_scenarios)} scenarios)",
+            _format_scenarios(unit_scenarios),
+            f"### Integration Tests ({len(integration_scenarios)} scenarios)",
+            _format_scenarios(integration_scenarios),
+            f"### E2E Tests ({len(e2e_scenarios)} scenarios)",
+            _format_scenarios(e2e_scenarios),
+            "## Generated Test Files",
+            "\n".join(all_test_files) if all_test_files else "_No test files generated._",
+            "",
+            "## Coverage Analysis",
+            output.get("coverage_analysis", ""),
+            "",
+            "## Detected Patterns",
+            f"- Strategies: {strategies}",
+            f"- Source types: {source_types}",
+            f"- Output types: {output_types}",
+        ]
+
+        md_path = output_dir / "test_plan.md"
+        md_path.write_text("\n".join(lines), encoding="utf-8")
+        logger.info(f"Wrote test plan: {md_path}")
+    except Exception as e:
+        logger.error(f"Failed to write test_plan.md: {e}")
+
+
+def _write_go_test_files(output: Dict[str, Any], output_dir: Path) -> None:
+    """Write Go test files to go_tests/ under output_dir."""
+    go_tests_dir = output_dir / "go_tests"
+    sections = {
+        "unit_tests": output.get("unit_tests", {}),
+        "integration_tests": output.get("integration_tests", {}),
+        "e2e_tests": output.get("e2e_tests", {}),
+    }
+    for section_name, files in sections.items():
+        if not isinstance(files, dict):
+            continue
+        for full_path, code in files.items():
+            if not code:
+                continue
+            dest = go_tests_dir / full_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(code, encoding="utf-8")
+            logger.info(f"Wrote Go test file: {dest}")

--- a/scripts/test_agents.py
+++ b/scripts/test_agents.py
@@ -240,7 +240,7 @@ class AgentTester:
                 logger.info("Calling real Testing Agent")
                 from agents.testing_agent import run_testing
 
-                output = run_testing(context)
+                output = run_testing(context, output_dir=self.output_dir)
                 log_api_call(logger, "claude-sonnet-4", 8000, dry_run=False)
 
             log_agent_complete(logger, "testing", output)
@@ -532,131 +532,14 @@ class AgentTester:
         return results
 
     def _write_test_plan_md(self, output: Dict[str, Any]) -> None:
-        """Write a human-readable test plan to test_plan.md in the output directory.
-
-        Args:
-            output: Testing agent output dictionary
-        """
-        try:
-            issue_title = output.get("issue_title") or "Feature"
-
-            # Collect scenarios by type from test_specifications
-            specs = output.get("test_specifications", {})
-            unit_scenarios: list = []
-            integration_scenarios: list = []
-            e2e_scenarios: list = []
-
-            # test_specifications may be a dict with spec IDs as keys
-            # or a dict with a top-level "scenarios" list (parsed YAML).
-            if isinstance(specs, dict):
-                raw_scenarios = specs.get("scenarios")
-                if isinstance(raw_scenarios, list):
-                    # Parsed YAML format: {"scenarios": [...]}
-                    for s in raw_scenarios:
-                        t = s.get("type", "")
-                        if t == "unit":
-                            unit_scenarios.append(s)
-                        elif t == "integration":
-                            integration_scenarios.append(s)
-                        elif t == "e2e":
-                            e2e_scenarios.append(s)
-                else:
-                    # Flat dict format: {id: {type, ...}, ...}
-                    for spec_id, spec in specs.items():
-                        if not isinstance(spec, dict):
-                            continue
-                        t = spec.get("type", "")
-                        entry = {"id": spec_id, **spec}
-                        if t == "unit":
-                            unit_scenarios.append(entry)
-                        elif t == "integration":
-                            integration_scenarios.append(entry)
-                        elif t == "e2e":
-                            e2e_scenarios.append(entry)
-
-            def _format_scenarios(scenarios: list) -> str:
-                if not scenarios:
-                    return "_No scenarios detected._\n"
-                lines = []
-                for s in scenarios:
-                    sid = s.get("id", "")
-                    desc = s.get("description", "")
-                    file_ = s.get("file", "")
-                    outcome = s.get("expected_outcome", "")
-                    lines.append(f"- **{sid}**: {desc}")
-                    if file_:
-                        lines.append(f"  - File: `{file_}`")
-                    if outcome:
-                        lines.append(f"  - Expected: {outcome}")
-                return "\n".join(lines) + "\n"
-
-            # Collect generated file paths
-            all_test_files: list = []
-            for section in ("unit_tests", "integration_tests", "e2e_tests"):
-                for path in output.get(section, {}).keys():
-                    all_test_files.append(f"- `go_tests/{path}`")
-
-            # Patterns
-            patterns = output.get("patterns_detected", {})
-            strategies = patterns.get("strategies", [])
-            source_types = patterns.get("source_types", [])
-            output_types = patterns.get("output_types", [])
-
-            lines = [
-                f"# Test Plan: {issue_title}",
-                "",
-                "## Test Strategy",
-                output.get("test_plan", ""),
-                "",
-                "## Test Coverage by Level",
-                "",
-                f"### Unit Tests ({len(unit_scenarios)} scenarios)",
-                _format_scenarios(unit_scenarios),
-                f"### Integration Tests ({len(integration_scenarios)} scenarios)",
-                _format_scenarios(integration_scenarios),
-                f"### E2E Tests ({len(e2e_scenarios)} scenarios)",
-                _format_scenarios(e2e_scenarios),
-                "## Generated Test Files",
-                "\n".join(all_test_files) if all_test_files else "_No test files generated._",
-                "",
-                "## Coverage Analysis",
-                output.get("coverage_analysis", ""),
-                "",
-                "## Detected Patterns",
-                f"- Strategies: {strategies}",
-                f"- Source types: {source_types}",
-                f"- Output types: {output_types}",
-            ]
-
-            md_path = self.output_dir / "test_plan.md"
-            md_path.write_text("\n".join(lines), encoding="utf-8")
-            self.logger.info(f"Wrote test plan: {md_path}")
-        except Exception as e:
-            self.logger.error(f"Failed to write test_plan.md: {e}")
+        """Write test_plan.md. Delegates to testing_agent module function."""
+        from agents.testing_agent import _write_test_plan_md as _agent_write_test_plan_md
+        _agent_write_test_plan_md(output, self.output_dir)
 
     def _write_go_test_files(self, output: Dict[str, Any]) -> None:
-        """Write individual Go test files to go_tests/ under the output directory.
-
-        Args:
-            output: Testing agent output dictionary containing unit_tests,
-                    integration_tests, and e2e_tests dicts mapping full_path -> code.
-        """
-        go_tests_dir = self.output_dir / "go_tests"
-        sections = {
-            "unit_tests": output.get("unit_tests", {}),
-            "integration_tests": output.get("integration_tests", {}),
-            "e2e_tests": output.get("e2e_tests", {}),
-        }
-        for section_name, files in sections.items():
-            if not isinstance(files, dict):
-                continue
-            for full_path, code in files.items():
-                if not code:
-                    continue
-                dest = go_tests_dir / full_path
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                dest.write_text(code, encoding="utf-8")
-                self.logger.info(f"Wrote Go test file: {dest}")
+        """Write Go test files. Delegates to testing_agent module function."""
+        from agents.testing_agent import _write_go_test_files as _agent_write_go_test_files
+        _agent_write_go_test_files(output, self.output_dir)
 
     def _save_artifact(self, filename: str, data: Any):
         """Save artifact to output directory.


### PR DESCRIPTION
Closes #36

## Summary
Moves `test_plan.md` and `go_tests/**/*_test.go` artifact writing from `scripts/test_agents.py` into `agents/testing_agent.py`'s `run_testing()` function, so artifacts are produced in both test mode (`test_agents.py`) and full pipeline mode (`orchestrate.py`).

## Changes
- `agents/testing_agent.py`: `run_testing()` now accepts `output_dir: Optional[Path] = None`; defaults to `/tmp/claude/testing-artifacts`. New module-level functions `_write_artifacts`, `_write_test_plan_md`, `_write_go_test_files` do the writing.
- `scripts/test_agents.py`: Passes `self.output_dir` to `run_testing()`; `AgentTester._write_test_plan_md` and `_write_go_test_files` become thin wrappers for backward compat.

## Testing
All 391 tests pass ✅