### PR TITLE
feat(orchestrate): add --output-dir to save all pipeline artifacts locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,11 @@ DRY_RUN=false
 # Set to true to review each phase output before continuing
 MANUAL_APPROVAL=false
 
+# Output directory for pipeline artifacts (optional)
+# When set, all generated files are saved here after pipeline completion.
+# Example: /tmp/output or ./output
+OUTPUT_DIR=
+
 # ----------------------------------------------------------------------------
 # Performance Tuning (OPTIONAL)
 # ----------------------------------------------------------------------------

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -5,7 +5,9 @@ Orchestrate the multi-agent workflow.
 Runs agents sequentially with output validation between phases.
 Set MANUAL_APPROVAL=true in .env to pause for user approval between phases.
 """
+import json
 import os
+import pathlib
 import sys
 import uuid
 import argparse
@@ -67,6 +69,109 @@ def print_final_summary(completed_phases: list[str], state: dict) -> None:
     print()
 
 
+# -- artifact saving ----------------------------------------------------------
+
+def _save_artifacts(state: dict, output_dir: str) -> pathlib.Path:
+    """Save all pipeline artifacts to a directory structure.
+
+    Args:
+        state: The final state dictionary from the orchestrate() workflow.
+        output_dir: Path to the root output directory (created if absent).
+
+    Returns:
+        The resolved output directory as a ``pathlib.Path``.
+    """
+    root = pathlib.Path(output_dir).resolve()
+    saved: list[str] = []
+
+    if root.exists() and any(root.iterdir()):
+        print(f"  WARNING: Output directory already exists and will be overwritten: {root}")
+
+    def _write(rel: pathlib.Path, content: str) -> None:
+        target = root / rel
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+            saved.append(str(rel))
+            print(f"  Saved: {rel}")
+        except OSError as e:
+            print(f"  ERROR saving {rel}: {e}")
+
+    # design/design_analysis.md
+    design_analysis = state.get("design_analysis")
+    if design_analysis:
+        _write(pathlib.Path("design") / "design_analysis.md", design_analysis)
+
+    # design/implementation_plan.md  (one item per line, prefixed with "- ")
+    implementation_plan = state.get("implementation_plan")
+    if implementation_plan:
+        lines = "\n".join(f"- {step}" for step in implementation_plan)
+        _write(pathlib.Path("design") / "implementation_plan.md", lines)
+
+    # code/<original_path>  — support both code_files and code_changes keys
+    code_dict: dict = state.get("code_files") or state.get("code_changes") or {}
+    for file_path, content in code_dict.items():
+        if content:
+            target = (root / "code" / file_path).resolve()
+            if not str(target).startswith(str(root.resolve()) + os.sep):
+                print(f"  SKIPPED (unsafe path): {file_path}")
+                continue
+            _write(pathlib.Path("code") / file_path, content)
+
+    # tests/unit/<filename>
+    for filename, content in (state.get("unit_tests") or {}).items():
+        if content:
+            target = (root / "tests" / "unit" / filename).resolve()
+            if not str(target).startswith(str(root.resolve()) + os.sep):
+                print(f"  SKIPPED (unsafe path): {filename}")
+                continue
+            _write(pathlib.Path("tests") / "unit" / filename, content)
+
+    # tests/integration/<filename>
+    for filename, content in (state.get("integration_tests") or {}).items():
+        if content:
+            target = (root / "tests" / "integration" / filename).resolve()
+            if not str(target).startswith(str(root.resolve()) + os.sep):
+                print(f"  SKIPPED (unsafe path): {filename}")
+                continue
+            _write(pathlib.Path("tests") / "integration" / filename, content)
+
+    # tests/e2e/<filename>
+    for filename, content in (state.get("e2e_tests") or {}).items():
+        if content:
+            target = (root / "tests" / "e2e" / filename).resolve()
+            if not str(target).startswith(str(root.resolve()) + os.sep):
+                print(f"  SKIPPED (unsafe path): {filename}")
+                continue
+            _write(pathlib.Path("tests") / "e2e" / filename, content)
+
+    # docs/pr_description.md
+    pr_description = state.get("pr_description")
+    if pr_description:
+        _write(pathlib.Path("docs") / "pr_description.md", pr_description)
+
+    # docs/pr_summary.md
+    pr_summary = state.get("pr_summary")
+    if pr_summary:
+        _write(pathlib.Path("docs") / "pr_summary.md", pr_summary)
+
+    # docs/release_notes.md
+    release_notes = state.get("release_notes")
+    if release_notes:
+        _write(pathlib.Path("docs") / "release_notes.md", release_notes)
+
+    # state.json — filter to JSON-serializable primitive fields only
+    serializable_state: dict = {}
+    for key, value in state.items():
+        if isinstance(value, (str, int, float, bool, list, dict, type(None))):
+            serializable_state[key] = value
+    state_json = json.dumps(serializable_state, indent=2, default=str)
+    _write(pathlib.Path("state.json"), state_json)
+
+    print(f"\n  Artifacts written to: {root}  ({len(saved)} files)")
+    return root
+
+
 # -- main workflow ------------------------------------------------------------
 
 def orchestrate(
@@ -76,6 +181,7 @@ def orchestrate(
     repo_path: str = None,
     jira_ticket: str = None,
     dry_run: bool = False,
+    output_dir: str = None,
 ) -> dict:
     """Run the full multi-agent workflow with validation and optional approval.
 
@@ -86,6 +192,7 @@ def orchestrate(
         repo_path: Optional path to the Shipwright repository for code analysis.
         jira_ticket: Optional Jira ticket ID to fetch title/description from.
         dry_run: If True, use mock data instead of real API calls.
+        output_dir: Optional path to save all pipeline artifacts after completion.
 
     Returns:
         Final accumulated state dictionary. The key ``current_phase`` will be
@@ -109,172 +216,178 @@ def orchestrate(
     if MANUAL_APPROVAL:
         print("  You will be asked to approve each phase before continuing.")
 
-    # -- Pre-phase: Jira ticket fetch ----------------------------------------
-    if jira_ticket:
-        print_header(f"Fetching Jira Ticket: {jira_ticket}")
-        _dry_run_set_by_us = False
-        if dry_run and os.getenv("DRY_RUN", "").lower() != "true":
-            os.environ["DRY_RUN"] = "true"
-            _dry_run_set_by_us = True
+    try:
+        # -- Pre-phase: Jira ticket fetch ----------------------------------------
+        if jira_ticket:
+            print_header(f"Fetching Jira Ticket: {jira_ticket}")
+            _dry_run_set_by_us = False
+            if dry_run and os.getenv("DRY_RUN", "").lower() != "true":
+                os.environ["DRY_RUN"] = "true"
+                _dry_run_set_by_us = True
+            try:
+                from skills import default_registry
+                jira_state = default_registry.get("fetch_jira_ticket").run({"ticket_id": jira_ticket})
+
+                state.update(jira_state)
+                title = state["issue_title"]
+                description = state["issue_description"]
+                issue_type = state["issue_type"]
+
+                print(f"  Ticket:   {jira_ticket}")
+                print(f"  Title:    {title}")
+                print(f"  Priority: {state.get('jira_priority', 'N/A')}")
+                labels = ', '.join(state.get('jira_labels', [])) or 'none'
+                print(f"  Labels:   {labels}")
+                linked = ', '.join(state.get('jira_linked_issues', [])) or 'none'
+                print(f"  Linked:   {linked}")
+                print(f"  URL:      {state.get('jira_ticket_url', '')}")
+
+                # -- GitHub PR enrichment (optional) --
+                github_pr_urls = state.get("github_pr_urls", [])
+                if github_pr_urls:
+                    try:
+                        github_pr_data_result = default_registry.get("fetch_github_prs").run({"pr_urls": github_pr_urls})
+                        github_pr_data = github_pr_data_result["pr_data"]
+                        state["github_pr_data"] = github_pr_data
+                        print(f"  GitHub PRs: {len(github_pr_data)} PR(s) fetched")
+                        for pr in github_pr_data:
+                            print(f"    #{pr['pr_number']} [{pr['state']}] {pr['title']}")
+                    except Exception as e:
+                        print(f"  GitHub PR fetch failed (non-blocking): {e}")
+            except ConnectionError as e:
+                print(f"\n  ERROR: {e}")
+                return state
+            except Exception as e:
+                print(f"\n  Failed to fetch Jira ticket: {e}")
+                return state
+            finally:
+                if _dry_run_set_by_us:
+                    os.environ.pop("DRY_RUN", None)
+
+        # -- Phase 1: Design ------------------------------------------------------
+        print_header("Phase 1: Design Agent")
+        from agents.design_agent import run_design
         try:
-            from skills import default_registry
-            jira_state = default_registry.get("fetch_jira_ticket").run({"ticket_id": jira_ticket})
-
-            state.update(jira_state)
-            title = state["issue_title"]
-            description = state["issue_description"]
-            issue_type = state["issue_type"]
-
-            print(f"  Ticket:   {jira_ticket}")
-            print(f"  Title:    {title}")
-            print(f"  Priority: {state.get('jira_priority', 'N/A')}")
-            labels = ', '.join(state.get('jira_labels', [])) or 'none'
-            print(f"  Labels:   {labels}")
-            linked = ', '.join(state.get('jira_linked_issues', [])) or 'none'
-            print(f"  Linked:   {linked}")
-            print(f"  URL:      {state.get('jira_ticket_url', '')}")
-
-            # -- GitHub PR enrichment (optional) --
-            github_pr_urls = state.get("github_pr_urls", [])
-            if github_pr_urls:
-                try:
-                    github_pr_data_result = default_registry.get("fetch_github_prs").run({"pr_urls": github_pr_urls})
-                    github_pr_data = github_pr_data_result["pr_data"]
-                    state["github_pr_data"] = github_pr_data
-                    print(f"  GitHub PRs: {len(github_pr_data)} PR(s) fetched")
-                    for pr in github_pr_data:
-                        print(f"    #{pr['pr_number']} [{pr['state']}] {pr['title']}")
-                except Exception as e:
-                    print(f"  GitHub PR fetch failed (non-blocking): {e}")
-        except ConnectionError as e:
-            print(f"\n  ERROR: {e}")
-            return state
+            design_output = run_design(title, description, repo_path=repo_path)
+            state.update(design_output)
+            state["current_phase"] = "design_complete"
         except Exception as e:
-            print(f"\n  Failed to fetch Jira ticket: {e}")
+            print(f"  Design Agent failed: {e}")
             return state
-        finally:
-            if _dry_run_set_by_us:
-                os.environ.pop("DRY_RUN", None)
 
-    # -- Phase 1: Design ------------------------------------------------------
-    print_header("Phase 1: Design Agent")
-    from agents.design_agent import run_design
-    try:
-        design_output = run_design(title, description, repo_path=repo_path)
-        state.update(design_output)
-        state["current_phase"] = "design_complete"
-    except Exception as e:
-        print(f"  Design Agent failed: {e}")
-        return state
+        result = validate_phase("design", state)
+        print_phase_summary("Design", result)
+        if not result.passed:
+            print("  Stopping workflow due to validation failure.")
+            print("  Fix the issues above before continuing.")
+            return state
+        completed_phases.append("design")
+        if not request_approval("design", "development"):
+            print("  Workflow stopped by user after Design phase.")
+            print_final_summary(completed_phases, state)
+            return state
 
-    result = validate_phase("design", state)
-    print_phase_summary("Design", result)
-    if not result.passed:
-        print("  Stopping workflow due to validation failure.")
-        print("  Fix the issues above before continuing.")
-        return state
-    completed_phases.append("design")
-    if not request_approval("design", "development"):
-        print("  Workflow stopped by user after Design phase.")
+        # -- Phase 2: Development -------------------------------------------------
+        print_header("Phase 2: Development Agent")
+        from agents.go_k8s_developer import run_development
+        try:
+            develop_output = run_development(state)
+            state.update(develop_output)
+            state["current_phase"] = "develop_complete"
+        except Exception as e:
+            print(f"  Development Agent failed: {e}")
+            return state
+
+        result = validate_phase("develop", state)
+        print_phase_summary("Development", result)
+        if not result.passed:
+            print("  Stopping workflow due to validation failure.")
+            return state
+        completed_phases.append("develop")
+        if not request_approval("develop", "testing"):
+            print("  Workflow stopped by user after Development phase.")
+            print_final_summary(completed_phases, state)
+            return state
+
+        # -- Phase 3: Testing -----------------------------------------------------
+        print_header("Phase 3: Testing Agent")
+        from agents.testing_agent import run_testing
+        try:
+            context = {
+                "design_analysis": state.get("design_analysis", ""),
+                "impacted_components": state.get("impacted_components", []),
+                "acceptance_criteria": state.get("acceptance_criteria", []),
+                "risks": state.get("risks", []),
+                "implementation_plan": state.get("implementation_plan", []),
+                "issue_title": title,
+                "issue_description": description,
+                "issue_type": issue_type,
+            }
+            testing_output = run_testing(context)
+            state.update(testing_output)
+            state["current_phase"] = "testing_complete"
+        except Exception as e:
+            print(f"  Testing Agent failed: {e}")
+            return state
+
+        result = validate_phase("testing", state)
+        print_phase_summary("Testing", result)
+        if not result.passed:
+            print("  Stopping workflow due to validation failure.")
+            return state
+        completed_phases.append("testing")
+        if not request_approval("testing", "documentation"):
+            print("  Workflow stopped by user after Testing phase.")
+            print_final_summary(completed_phases, state)
+            return state
+
+        # -- Phase 4: Documentation -----------------------------------------------
+        print_header("Phase 4: Documentation Agent")
+        from agents.docs_agent import run_docs
+        try:
+            context = {
+                "issue_title": title,
+                "issue_description": description,
+                "issue_type": issue_type,
+                "design_analysis": state.get("design_analysis", ""),
+                "implementation_plan": state.get("implementation_plan", []),
+                "impacted_components": state.get("impacted_components", []),
+                "risks": state.get("risks", []),
+                "acceptance_criteria": state.get("acceptance_criteria", []),
+                # development outputs
+                "code_changes": state.get("code_changes", {}),
+                "files_modified": state.get("files_modified", []),
+                "pr_description": state.get("pr_description", ""),
+                # testing outputs
+                "test_results": state.get("test_results", {}),
+                "test_summary": state.get("test_summary", ""),
+                "test_plan": state.get("test_plan", ""),
+                "coverage_gaps": state.get("coverage_gaps", []),
+                "test_failures": state.get("test_failures", []),
+                # repo context
+                "repo_path": repo_path or ".",
+                # github outputs
+                "github_pr_urls": state.get("github_pr_urls", []),
+                "github_pr_data": state.get("github_pr_data", []),
+            }
+            docs_output = run_docs(context)
+            state.update(docs_output)
+            state["current_phase"] = "done"
+        except Exception as e:
+            print(f"  Documentation Agent failed: {e}")
+            return state
+
+        result = validate_phase("docs", state)
+        print_phase_summary("Documentation", result)
+        completed_phases.append("docs")
+
         print_final_summary(completed_phases, state)
         return state
 
-    # -- Phase 2: Development -------------------------------------------------
-    print_header("Phase 2: Development Agent")
-    from agents.go_k8s_developer import run_development
-    try:
-        develop_output = run_development(state)
-        state.update(develop_output)
-        state["current_phase"] = "develop_complete"
-    except Exception as e:
-        print(f"  Development Agent failed: {e}")
-        return state
-
-    result = validate_phase("develop", state)
-    print_phase_summary("Development", result)
-    if not result.passed:
-        print("  Stopping workflow due to validation failure.")
-        return state
-    completed_phases.append("develop")
-    if not request_approval("develop", "testing"):
-        print("  Workflow stopped by user after Development phase.")
-        print_final_summary(completed_phases, state)
-        return state
-
-    # -- Phase 3: Testing -----------------------------------------------------
-    print_header("Phase 3: Testing Agent")
-    from agents.testing_agent import run_testing
-    try:
-        context = {
-            "design_analysis": state.get("design_analysis", ""),
-            "impacted_components": state.get("impacted_components", []),
-            "acceptance_criteria": state.get("acceptance_criteria", []),
-            "risks": state.get("risks", []),
-            "implementation_plan": state.get("implementation_plan", []),
-            "issue_title": title,
-            "issue_description": description,
-            "issue_type": issue_type,
-        }
-        testing_output = run_testing(context)
-        state.update(testing_output)
-        state["current_phase"] = "testing_complete"
-    except Exception as e:
-        print(f"  Testing Agent failed: {e}")
-        return state
-
-    result = validate_phase("testing", state)
-    print_phase_summary("Testing", result)
-    if not result.passed:
-        print("  Stopping workflow due to validation failure.")
-        return state
-    completed_phases.append("testing")
-    if not request_approval("testing", "documentation"):
-        print("  Workflow stopped by user after Testing phase.")
-        print_final_summary(completed_phases, state)
-        return state
-
-    # -- Phase 4: Documentation -----------------------------------------------
-    print_header("Phase 4: Documentation Agent")
-    from agents.docs_agent import run_docs
-    try:
-        context = {
-            "issue_title": title,
-            "issue_description": description,
-            "issue_type": issue_type,
-            "design_analysis": state.get("design_analysis", ""),
-            "implementation_plan": state.get("implementation_plan", []),
-            "impacted_components": state.get("impacted_components", []),
-            "risks": state.get("risks", []),
-            "acceptance_criteria": state.get("acceptance_criteria", []),
-            # development outputs
-            "code_changes": state.get("code_changes", {}),
-            "files_modified": state.get("files_modified", []),
-            "pr_description": state.get("pr_description", ""),
-            # testing outputs
-            "test_results": state.get("test_results", {}),
-            "test_summary": state.get("test_summary", ""),
-            "test_plan": state.get("test_plan", ""),
-            "coverage_gaps": state.get("coverage_gaps", []),
-            "test_failures": state.get("test_failures", []),
-            # repo context
-            "repo_path": repo_path or ".",
-            # github outputs
-            "github_pr_urls": state.get("github_pr_urls", []),
-            "github_pr_data": state.get("github_pr_data", []),
-        }
-        docs_output = run_docs(context)
-        state.update(docs_output)
-        state["current_phase"] = "done"
-    except Exception as e:
-        print(f"  Documentation Agent failed: {e}")
-        return state
-
-    result = validate_phase("docs", state)
-    print_phase_summary("Documentation", result)
-    completed_phases.append("docs")
-
-    print_final_summary(completed_phases, state)
-    return state
+    finally:
+        if output_dir and state.get("current_phase") not in (None, "init"):
+            print_header("Saving Artifacts")
+            _save_artifacts(state, output_dir)
 
 
 def main() -> None:
@@ -313,6 +426,12 @@ Examples:
         action="store_true",
         help="Use mock data instead of real API calls (no Jira or Claude API calls).",
     )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        metavar="PATH",
+        help="Save all pipeline artifacts to this directory after completion.",
+    )
     args = parser.parse_args()
 
     if not args.jira_ticket and not args.title:
@@ -325,6 +444,7 @@ Examples:
         repo_path=args.repo_path,
         jira_ticket=args.jira_ticket,
         dry_run=args.dry_run,
+        output_dir=args.output_dir,
     )
     sys.exit(0 if result.get("current_phase") == "done" else 1)
 

--- a/tests/test_orchestrate_output_dir.py
+++ b/tests/test_orchestrate_output_dir.py
@@ -1,0 +1,423 @@
+"""Tests for _save_artifacts() in scripts/orchestrate.py and the --output-dir CLI arg.
+
+Covers:
+  - All artifact categories (design, code, tests, docs, state.json)
+  - Edge cases: empty/None fields, path traversal, write errors, partial state
+  - CLI argument wiring via orchestrate() mock
+"""
+
+import json
+import os
+import sys
+import pathlib
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make scripts/ importable without installing the package.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = pathlib.Path(__file__).parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from orchestrate import _save_artifacts  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _files_under(directory: pathlib.Path) -> set[str]:
+    """Return relative POSIX paths of all files under *directory*."""
+    return {p.relative_to(directory).as_posix() for p in directory.rglob("*") if p.is_file()}
+
+
+# ---------------------------------------------------------------------------
+# TestSaveArtifacts
+# ---------------------------------------------------------------------------
+
+
+class TestSaveArtifacts:
+    """Unit tests for _save_artifacts()."""
+
+    # ------------------------------------------------------------------
+    # 1. design_analysis → design/design_analysis.md
+    # ------------------------------------------------------------------
+
+    def test_design_analysis_saved(self, tmp_path):
+        state = {"design_analysis": "# My Design\n\nSome content.", "current_phase": "design_complete"}
+        _save_artifacts(state, str(tmp_path))
+
+        target = tmp_path / "design" / "design_analysis.md"
+        assert target.exists(), "design/design_analysis.md should be written"
+        assert _read(target) == "# My Design\n\nSome content."
+
+    # ------------------------------------------------------------------
+    # 2. implementation_plan list → design/implementation_plan.md with "- " bullets
+    # ------------------------------------------------------------------
+
+    def test_implementation_plan_saved_as_bullets(self, tmp_path):
+        steps = ["Update API types", "Add webhook validation", "Write tests"]
+        state = {"implementation_plan": steps, "current_phase": "design_complete"}
+        _save_artifacts(state, str(tmp_path))
+
+        target = tmp_path / "design" / "implementation_plan.md"
+        assert target.exists(), "design/implementation_plan.md should be written"
+        content = _read(target)
+        for step in steps:
+            assert f"- {step}" in content
+
+    # ------------------------------------------------------------------
+    # 3. code_files preserve sub-directory paths under code/
+    # ------------------------------------------------------------------
+
+    def test_code_files_preserve_paths(self, tmp_path):
+        state = {
+            "code_files": {
+                "pkg/webhook/handler.go": "package webhook\n",
+            },
+            "current_phase": "develop_complete",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        target = tmp_path / "code" / "pkg" / "webhook" / "handler.go"
+        assert target.exists(), "code/pkg/webhook/handler.go should be written"
+        assert _read(target) == "package webhook\n"
+
+    # ------------------------------------------------------------------
+    # 4. unit_tests → tests/unit/
+    # ------------------------------------------------------------------
+
+    def test_unit_tests_saved(self, tmp_path):
+        state = {
+            "unit_tests": {
+                "buildrun_test.go": "package buildrun_test\n",
+                "webhook_test.go": "package webhook_test\n",
+            },
+            "current_phase": "testing_complete",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        assert (tmp_path / "tests" / "unit" / "buildrun_test.go").exists()
+        assert (tmp_path / "tests" / "unit" / "webhook_test.go").exists()
+        assert _read(tmp_path / "tests" / "unit" / "buildrun_test.go") == "package buildrun_test\n"
+
+    # ------------------------------------------------------------------
+    # 5. integration_tests → tests/integration/
+    # ------------------------------------------------------------------
+
+    def test_integration_tests_saved(self, tmp_path):
+        state = {
+            "integration_tests": {
+                "e2e_suite_test.go": "package integration_test\n",
+            },
+            "current_phase": "testing_complete",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        target = tmp_path / "tests" / "integration" / "e2e_suite_test.go"
+        assert target.exists()
+        assert _read(target) == "package integration_test\n"
+
+    # ------------------------------------------------------------------
+    # 6. e2e_tests → tests/e2e/
+    # ------------------------------------------------------------------
+
+    def test_e2e_tests_saved(self, tmp_path):
+        state = {
+            "e2e_tests": {
+                "smoke_test.go": "package e2e_test\n",
+            },
+            "current_phase": "testing_complete",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        target = tmp_path / "tests" / "e2e" / "smoke_test.go"
+        assert target.exists()
+        assert _read(target) == "package e2e_test\n"
+
+    # ------------------------------------------------------------------
+    # 7. docs artifacts → docs/
+    # ------------------------------------------------------------------
+
+    def test_docs_artifacts_saved(self, tmp_path):
+        state = {
+            "pr_description": "## PR description",
+            "pr_summary": "Short summary",
+            "release_notes": "## v1.0.0 release notes",
+            "current_phase": "done",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        assert (tmp_path / "docs" / "pr_description.md").exists()
+        assert (tmp_path / "docs" / "pr_summary.md").exists()
+        assert (tmp_path / "docs" / "release_notes.md").exists()
+
+        assert _read(tmp_path / "docs" / "pr_description.md") == "## PR description"
+        assert _read(tmp_path / "docs" / "pr_summary.md") == "Short summary"
+        assert _read(tmp_path / "docs" / "release_notes.md") == "## v1.0.0 release notes"
+
+    # ------------------------------------------------------------------
+    # 8. state.json always written with JSON-serializable fields
+    # ------------------------------------------------------------------
+
+    def test_state_json_written(self, tmp_path):
+        state = {
+            "session_id": "abc123",
+            "current_phase": "done",
+            "issue_title": "Add timeout",
+            "non_serializable": object(),  # should be excluded or stringified
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        state_file = tmp_path / "state.json"
+        assert state_file.exists(), "state.json must always be written"
+
+        data = json.loads(_read(state_file))
+        assert data["session_id"] == "abc123"
+        assert data["current_phase"] == "done"
+        assert data["issue_title"] == "Add timeout"
+        # non_serializable is not a primitive type, so it should be absent
+        assert "non_serializable" not in data
+
+    # ------------------------------------------------------------------
+    # 9. empty string/list/dict fields produce no extra files
+    # ------------------------------------------------------------------
+
+    def test_empty_fields_not_written(self, tmp_path):
+        state = {
+            "design_analysis": "",          # empty string
+            "implementation_plan": [],       # empty list
+            "code_files": {},               # empty dict
+            "unit_tests": {},
+            "integration_tests": {},
+            "e2e_tests": {},
+            "pr_description": "",
+            "pr_summary": "",
+            "release_notes": "",
+            "current_phase": "init",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        files = _files_under(tmp_path)
+        # Only state.json should be written
+        assert files == {"state.json"}, (
+            f"Only state.json expected, but found: {files}"
+        )
+
+    # ------------------------------------------------------------------
+    # 10. None fields produce no files
+    # ------------------------------------------------------------------
+
+    def test_none_fields_not_written(self, tmp_path):
+        state = {
+            "design_analysis": None,
+            "implementation_plan": None,
+            "code_files": None,
+            "unit_tests": None,
+            "integration_tests": None,
+            "e2e_tests": None,
+            "pr_description": None,
+            "pr_summary": None,
+            "release_notes": None,
+            "current_phase": "init",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        files = _files_under(tmp_path)
+        assert files == {"state.json"}, (
+            f"Only state.json expected, but found: {files}"
+        )
+
+    # ------------------------------------------------------------------
+    # 11. path traversal blocked
+    # ------------------------------------------------------------------
+
+    def test_path_traversal_blocked(self, tmp_path):
+        evil_key = "../../evil.txt"
+        state = {
+            "code_files": {evil_key: "malicious content"},
+            "current_phase": "develop_complete",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        # The file must NOT appear outside the output root
+        evil_target = (tmp_path / "code" / evil_key).resolve()
+        assert not evil_target.exists(), "Path traversal file must not be created"
+
+        # Nothing outside tmp_path should have been created
+        outside = tmp_path.parent / "evil.txt"
+        assert not outside.exists(), "evil.txt must not appear outside output dir"
+
+    # ------------------------------------------------------------------
+    # 12. existing dir with files prints a warning
+    # ------------------------------------------------------------------
+
+    def test_existing_dir_warns(self, tmp_path):
+        # Pre-populate the directory
+        existing_file = tmp_path / "old_artifact.txt"
+        existing_file.write_text("old data")
+
+        state = {"design_analysis": "new content", "current_phase": "design_complete"}
+
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            _save_artifacts(state, str(tmp_path))
+
+        output = captured.getvalue()
+        assert "WARNING" in output or "already exists" in output.lower(), (
+            "Expected a warning about existing output directory, got: " + output
+        )
+
+    # ------------------------------------------------------------------
+    # 13. OSError on one file does not abort remaining files
+    # ------------------------------------------------------------------
+
+    def test_write_error_does_not_abort(self, tmp_path):
+        state = {
+            "design_analysis": "design content",
+            "pr_summary": "summary content",
+            "current_phase": "done",
+        }
+
+        original_write_text = pathlib.Path.write_text
+        call_count = {"n": 0}
+
+        def _selective_fail(self, content, **kwargs):
+            call_count["n"] += 1
+            # Fail only on the first write (design_analysis.md)
+            if "design_analysis" in str(self):
+                raise OSError("Simulated disk error")
+            return original_write_text(self, content, **kwargs)
+
+        with patch.object(pathlib.Path, "write_text", _selective_fail):
+            _save_artifacts(state, str(tmp_path))
+
+        # pr_summary.md should still have been written despite earlier failure
+        assert (tmp_path / "docs" / "pr_summary.md").exists(), (
+            "Remaining files must be saved even after a single write failure"
+        )
+
+    # ------------------------------------------------------------------
+    # 14. partial pipeline state (only design_analysis, no code/tests/docs)
+    # ------------------------------------------------------------------
+
+    def test_partial_pipeline_state(self, tmp_path):
+        state = {
+            "design_analysis": "# Partial design",
+            "current_phase": "design_complete",
+            # No code_files, no tests, no docs fields at all
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        files = _files_under(tmp_path)
+        assert "design/design_analysis.md" in files
+        # No code/, tests/, or docs/ directories should have been created
+        assert not any(f.startswith("code/") for f in files)
+        assert not any(f.startswith("tests/") for f in files)
+        assert not any(f.startswith("docs/") for f in files)
+
+    # ------------------------------------------------------------------
+    # 15. code_changes fallback when code_files absent
+    # ------------------------------------------------------------------
+
+    def test_code_changes_fallback(self, tmp_path):
+        state = {
+            # No "code_files" key
+            "code_changes": {
+                "pkg/api/types.go": "package api\n",
+            },
+            "current_phase": "develop_complete",
+        }
+        _save_artifacts(state, str(tmp_path))
+
+        target = tmp_path / "code" / "pkg" / "api" / "types.go"
+        assert target.exists(), (
+            "code_changes should be used as fallback when code_files is absent"
+        )
+        assert _read(target) == "package api\n"
+
+
+# ---------------------------------------------------------------------------
+# TestOrchestrateOutputDirArg
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestrateOutputDirArg:
+    """Tests that --output-dir is correctly wired through the CLI to orchestrate()."""
+
+    # Patch target: orchestrate() as imported inside scripts/orchestrate.py main()
+    _PATCH_TARGET = "orchestrate.orchestrate"
+
+    def _run_main(self, argv: list[str]) -> None:
+        """Run main() with the given argv list, suppressing SystemExit."""
+        import orchestrate as _mod
+
+        with patch.object(_mod, "orchestrate", return_value={"current_phase": "done"}) as mock_orch:
+            with patch("sys.argv", ["orchestrate.py"] + argv):
+                try:
+                    _mod.main()
+                except SystemExit:
+                    pass
+            return mock_orch
+
+    # ------------------------------------------------------------------
+    # 16. --output-dir /tmp/x → orchestrate(output_dir="/tmp/x")
+    # ------------------------------------------------------------------
+
+    def test_output_dir_passed_to_orchestrate(self, tmp_path):
+        import orchestrate as _mod
+
+        with patch.object(_mod, "orchestrate", return_value={"current_phase": "done"}) as mock_orch:
+            with patch("sys.argv", [
+                "orchestrate.py",
+                "--title", "Test feature",
+                "--output-dir", str(tmp_path),
+            ]):
+                try:
+                    _mod.main()
+                except SystemExit:
+                    pass
+
+        mock_orch.assert_called_once()
+        _, kwargs = mock_orch.call_args
+        assert kwargs.get("output_dir") == str(tmp_path), (
+            f"Expected output_dir={str(tmp_path)!r}, got {kwargs.get('output_dir')!r}"
+        )
+
+    # ------------------------------------------------------------------
+    # 17. no --output-dir → orchestrate(output_dir=None)
+    # ------------------------------------------------------------------
+
+    def test_no_output_dir_by_default(self, tmp_path):
+        import orchestrate as _mod
+
+        with patch.object(_mod, "orchestrate", return_value={"current_phase": "done"}) as mock_orch:
+            with patch("sys.argv", [
+                "orchestrate.py",
+                "--title", "Test feature",
+            ]):
+                try:
+                    _mod.main()
+                except SystemExit:
+                    pass
+
+        mock_orch.assert_called_once()
+        _, kwargs = mock_orch.call_args
+        assert kwargs.get("output_dir") is None, (
+            f"Expected output_dir=None when flag omitted, got {kwargs.get('output_dir')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #55

## Summary

Adds `--output-dir <path>` to `scripts/orchestrate.py` so all pipeline artifacts are saved to disk after each run — enabling review, replay, and downstream publishing.

## Output Directory Structure

```
<output-dir>/
├── design/
│   ├── design_analysis.md
│   └── implementation_plan.md
├── code/                        # preserves original Go file paths
│   └── pkg/webhook/github/
│       └── handler.go
├── tests/
│   ├── unit/
│   ├── integration/
│   └── e2e/
├── docs/
│   ├── pr_description.md
│   ├── pr_summary.md
│   └── release_notes.md
└── state.json                   # full state for downstream publish.py
```

## Usage

```bash
uv run python scripts/orchestrate.py \
  --jira-ticket BUILD-1707 \
  --output-dir ./output/BUILD-1707
```

## Changes

- `scripts/orchestrate.py`: `_save_artifacts()` helper + `--output-dir` CLI arg
- `.env.example`: `OUTPUT_DIR=` optional var added
- `tests/test_orchestrate_output_dir.py`: 17 new tests

## Security

- Path traversal guard on all agent-generated file paths (rejects `../../evil` keys)
- `output_dir` not stored in pipeline state (CLI concern only)
- `OSError` resilience: single file failure does not abort the full save

## Testing

17/17 tests pass including path traversal, partial pipeline state, code_changes fallback, and OSError resilience.