### PR TITLE
fix(design-agent): parser misses implementation_plan items

### DIFF
--- a/agents/design_agent.py
+++ b/agents/design_agent.py
@@ -9,6 +9,7 @@ implementation planning.
 """
 
 import os
+import re
 from typing import Dict, Any, Optional
 
 from config.agent_prompts import DESIGN_AGENT_PROMPT
@@ -334,8 +335,8 @@ def _parse_design_output(design_text: str) -> Dict[str, Any]:
         elif "### Implementation Plan" in line or "## Implementation Plan" in line:
             current_section = "implementation_plan"
             continue
-        elif line_stripped.startswith("##") or line_stripped.startswith("###"):
-            # New section that we're not tracking
+        elif line_stripped.startswith("##") and not line_stripped.startswith("###"):
+            # New ## section that we're not tracking; ### subheadings do NOT reset
             current_section = None
             continue
 
@@ -344,6 +345,12 @@ def _parse_design_output(design_text: str) -> Dict[str, Any]:
             item = line_stripped[1:].strip()
             if item:
                 result[current_section].append(item)
+        elif current_section:
+            numbered = re.match(r'^\d+\.\s+(.*)', line_stripped)
+            if numbered:
+                item = numbered.group(1).strip()
+                if item:
+                    result[current_section].append(item)
 
     # Also extract component names mentioned in the document
     for component_name in COMPONENTS.keys():


### PR DESCRIPTION
## Bug
`_parse_design_output` returned empty `implementation_plan`, `risks`, and `acceptance_criteria` from real Claude responses.

## Root causes
1. `### Phase N` subheadings inside `## Implementation Plan` reset `current_section` to `None` because `"###".startswith("##")` is `True`
2. Numbered list items (`1.`, `2.`) were not collected — only `- bullets`

## Fix
- Changed catch-all to `startswith("##") and not startswith("###")`
- Added `re.match(r'^\d+\.\s+(.*)')` collection for numbered items

## Tests
14 passed, 1 skipped in `test_agents_validator_design.py`