### PR TITLE
fix(dashboard): heartbeat timestamps crash enricher with timezone mismatch

### DIFF
--- a/dashboard/enrichers.py
+++ b/dashboard/enrichers.py
@@ -232,6 +232,10 @@ class TimestampEnricher(Enricher):
         if timestamp_str:
             try:
                 timestamp = datetime.fromisoformat(timestamp_str.replace('Z', '+00:00'))
+                # If still offset-naive (e.g. produced by datetime.utcnow().isoformat()),
+                # attach UTC so subtraction against an aware datetime doesn't raise TypeError.
+                if timestamp.tzinfo is None:
+                    timestamp = timestamp.replace(tzinfo=timezone.utc)
                 heartbeat["timestamp_formatted"] = timestamp.strftime("%Y-%m-%d %H:%M:%S")
                 heartbeat["timestamp_relative"] = self._relative_time(timestamp)
             except (ValueError, AttributeError):

--- a/dashboard/heartbeat.py
+++ b/dashboard/heartbeat.py
@@ -6,7 +6,7 @@ state to the dashboard for real-time monitoring.
 
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional
 import requests
 
@@ -64,7 +64,7 @@ class Heartbeat:
         self.agent = agent
         self.phase = phase
         self.raw_state = raw_state
-        self.timestamp = timestamp or datetime.utcnow()
+        self.timestamp = timestamp or datetime.now(timezone.utc)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert heartbeat to dictionary for API transmission.


### PR DESCRIPTION
## Bug
Dashboard showed no agent updates during pipeline runs.

## Root cause
`heartbeat.py` used `datetime.utcnow()` (offset-naive). `enrichers.py` `_relative_time()` used `datetime.now(timezone.utc)` (offset-aware). Subtracting them raised `TypeError`, silently dropping all heartbeats before DB write.

## Fix
- `heartbeat.py`: changed to `datetime.now(timezone.utc)`
- `enrichers.py`: added `tzinfo=timezone.utc` guard for naive timestamps

## Tests
37 passed in dashboard/heartbeat/enricher tests