### PR TITLE
feat(dashboard): add stuck session detection and cleanup

### DIFF
--- a/dashboard/backend.py
+++ b/dashboard/backend.py
@@ -7,7 +7,7 @@ import json
 import os
 import sqlite3
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, List, Optional
 from contextlib import asynccontextmanager
 
@@ -312,6 +312,61 @@ class Database:
 
         return result
 
+    def cleanup_stuck_sessions(self, max_stale_hours: int = 6) -> dict:
+        """Delete sessions that have not received a heartbeat in max_stale_hours
+        AND whose phase is not 'done' or 'error' (i.e., stuck/incomplete).
+
+        Args:
+            max_stale_hours: Hours without a heartbeat before a session is
+                considered stuck
+
+        Returns:
+            dict with counts of deleted sessions and heartbeats, and session_ids
+        """
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=max_stale_hours)).isoformat()
+        conn = sqlite3.connect(self.db_path)
+        try:
+            # Find stuck session IDs: last heartbeat older than cutoff, phase not terminal
+            stuck = conn.execute("""
+                SELECT s.id
+                FROM sessions s
+                JOIN (
+                    SELECT session_id, MAX(timestamp) AS last_beat
+                    FROM heartbeats
+                    GROUP BY session_id
+                ) h ON s.id = h.session_id
+                WHERE h.last_beat < ?
+                  AND s.id NOT IN (
+                    SELECT DISTINCT session_id FROM heartbeats
+                    WHERE json_extract(raw_state, '$.current_phase') IN ('done', 'error')
+                  )
+            """, (cutoff,)).fetchall()
+            stuck_ids = [r[0] for r in stuck]
+            if not stuck_ids:
+                logger.info(f"No stuck sessions found (stale threshold: {max_stale_hours}h)")
+                return {"sessions_deleted": 0, "heartbeats_deleted": 0, "session_ids": []}
+            placeholders = ",".join("?" * len(stuck_ids))
+            hb_del = conn.execute(
+                f"DELETE FROM heartbeats WHERE session_id IN ({placeholders})", stuck_ids
+            )
+            s_del = conn.execute(
+                f"DELETE FROM sessions WHERE id IN ({placeholders})", stuck_ids
+            )
+            conn.commit()
+            result = {
+                "sessions_deleted": s_del.rowcount,
+                "heartbeats_deleted": hb_del.rowcount,
+                "session_ids": stuck_ids,
+            }
+            logger.info(
+                f"Cleaned up {result['sessions_deleted']} stuck sessions "
+                f"and {result['heartbeats_deleted']} heartbeats "
+                f"(stale threshold: {max_stale_hours}h): {stuck_ids}"
+            )
+            return result
+        finally:
+            conn.close()
+
     def clear_completed_sessions(self) -> dict:
         """Clear all completed or failed sessions (phase='done' or 'error').
 
@@ -376,6 +431,10 @@ async def periodic_cleanup():
             # Clean up sessions older than 24 hours
             result = db.cleanup_old_sessions(max_age_hours=24)
             logger.info(f"Automatic cleanup: {result}")
+
+            # Clean up stuck sessions (no heartbeat for 4+ hours, non-terminal)
+            stuck_result = db.cleanup_stuck_sessions(max_stale_hours=4)
+            logger.info(f"Automatic stuck session cleanup: {stuck_result}")
         except asyncio.CancelledError:
             logger.info("Periodic cleanup task cancelled")
             break
@@ -524,6 +583,24 @@ async def clear_completed_sessions():
     logger.info("Clear all completed/error sessions requested")
     result = db.clear_completed_sessions()
     logger.info(f"Manual session cleanup: {result}")
+    return result
+
+
+@app.delete("/api/sessions/stuck")
+async def delete_stuck_sessions(max_stale_hours: int = 6):
+    """Delete sessions that have not received a heartbeat in max_stale_hours
+    and are not in a terminal phase (done/error).
+
+    Args:
+        max_stale_hours: Hours without a heartbeat before a session is
+            considered stuck (default: 6)
+
+    Returns:
+        dict with sessions_deleted count, heartbeats_deleted count, and session_ids list
+    """
+    logger.info(f"Stuck session cleanup requested (max_stale_hours={max_stale_hours})")
+    result = db.cleanup_stuck_sessions(max_stale_hours=max_stale_hours)
+    logger.info(f"Stuck session cleanup: {result}")
     return result
 
 

--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -350,6 +350,53 @@
         .jira-badge:hover {
             background: #0065FF;
         }
+
+        .stale-badge {
+            display: inline-block;
+            background: #b45309;
+            color: #fef3c7;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            margin-left: 8px;
+            vertical-align: middle;
+        }
+
+        .session-card.stale {
+            border-color: #b45309;
+            opacity: 0.85;
+        }
+
+        .btn-secondary {
+            background-color: #6c757d;
+            color: white;
+        }
+
+        .btn-secondary:hover {
+            background-color: #5a6268;
+        }
+
+        .toast {
+            position: fixed;
+            bottom: 24px;
+            right: 24px;
+            background: #21262d;
+            border: 1px solid #30363d;
+            color: #c9d1d9;
+            padding: 12px 20px;
+            border-radius: 6px;
+            font-size: 14px;
+            z-index: 1000;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: none;
+        }
+
+        .toast.visible {
+            opacity: 1;
+        }
     </style>
 </head>
 <body>
@@ -362,6 +409,9 @@
             <button id="clearSessionsBtn" class="btn btn-danger">
                 Clear Completed Sessions
             </button>
+            <button id="clearStuckBtn" class="btn btn-secondary" title="Remove sessions that have not received updates in 6+ hours">
+                Clear Stuck Sessions
+            </button>
             <button id="refreshBtn" class="btn btn-primary">
                 Refresh
             </button>
@@ -372,6 +422,8 @@
         <button id="autoRefreshBtn" class="active">Auto-Refresh (5s)</button>
         <div class="status connected" id="statusIndicator">● Connected</div>
     </div>
+
+    <div id="toastEl" class="toast"></div>
 
     <div class="sessions-grid" id="sessionsGrid">
         <div class="empty-state">
@@ -395,6 +447,17 @@
         const refreshBtn = document.getElementById('refreshBtn');
         const autoRefreshBtn = document.getElementById('autoRefreshBtn');
         const clearSessionsBtn = document.getElementById('clearSessionsBtn');
+        const clearStuckBtn = document.getElementById('clearStuckBtn');
+        const toastEl = document.getElementById('toastEl');
+
+        // Show a brief toast notification
+        let toastTimer = null;
+        function showToast(message) {
+            toastEl.textContent = message;
+            toastEl.classList.add('visible');
+            if (toastTimer) clearTimeout(toastTimer);
+            toastTimer = setTimeout(() => toastEl.classList.remove('visible'), 3000);
+        }
 
         // Fetch sessions from API
         async function fetchSessions() {
@@ -446,6 +509,14 @@
             if (status === 'complete') statusClass = 'complete';
             else if (status === 'error') statusClass = 'error';
 
+            // Stale detection: last update older than 2 hours and not in terminal phase
+            const STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+            const lastUpdate = session.updated_at ? new Date(session.updated_at) : null;
+            const isTerminal = status === 'complete' || status === 'error';
+            const isStale = lastUpdate && !isTerminal && (Date.now() - lastUpdate.getTime()) > STALE_THRESHOLD_MS;
+            const staleHtml = isStale ? '<span class="stale-badge">STALE</span>' : '';
+            const cardStaleClass = isStale ? ' stale' : '';
+
             // Jira ticket badge
             const jiraHtml = session.jira_ticket_id ? `
                 <a href="${session.jira_ticket_url || '#'}" target="_blank" class="jira-badge">
@@ -476,13 +547,13 @@
                 'pending';
 
             return `
-                <div class="session-card" data-session-id="${session.id}">
+                <div class="session-card${cardStaleClass}" data-session-id="${session.id}">
                     <div class="session-header">
                         <div class="status-dot ${statusClass}"></div>
                         <span class="session-id">${session.id.substring(0, 8)}</span>
                     </div>
 
-                    <div class="issue-title">${session.issue_title || 'Unknown Task'}${jiraHtml}</div>
+                    <div class="issue-title">${session.issue_title || 'Unknown Task'}${jiraHtml}${staleHtml}</div>
                     <span class="issue-type ${session.issue_type || 'feature'}">${session.issue_type || 'feature'}</span>
 
                     <div class="agents-status">
@@ -588,6 +659,34 @@
                 // Re-enable button
                 clearSessionsBtn.disabled = false;
                 clearSessionsBtn.textContent = 'Clear Completed Sessions';
+            }
+        });
+
+        // Clear stuck sessions button
+        clearStuckBtn.addEventListener('click', async () => {
+            if (!confirm('Clear all stuck/incomplete sessions (no update in 6+ hours)?')) return;
+
+            clearStuckBtn.disabled = true;
+            clearStuckBtn.textContent = 'Clearing...';
+
+            try {
+                const response = await fetch(`${API_BASE}/api/sessions/stuck?max_stale_hours=6`, {
+                    method: 'DELETE'
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                showToast(`Cleared ${data.sessions_deleted} stuck session(s)`);
+                await fetchSessions();
+            } catch (error) {
+                console.error('Error clearing stuck sessions:', error);
+                showToast('Failed to clear stuck sessions. Please try again.');
+            } finally {
+                clearStuckBtn.disabled = false;
+                clearStuckBtn.textContent = 'Clear Stuck Sessions';
             }
         });
 

--- a/tests/test_dashboard_cleanup.py
+++ b/tests/test_dashboard_cleanup.py
@@ -209,6 +209,67 @@ def test_cleanup_no_sessions():
     print("✓ Test passed!")
 
 
+def test_cleanup_stuck_sessions():
+    """Test cleanup_stuck_sessions method."""
+    print("\n=== Test: cleanup_stuck_sessions ===")
+
+    db = setup_test_db()
+
+    # Stuck sessions: old heartbeat, non-terminal phase (should be deleted)
+    insert_test_session(db, "stuck_1", "planning", hours_ago=8)
+    insert_test_session(db, "stuck_2", "executing", hours_ago=10)
+
+    # Terminal sessions that are old: should NOT be deleted (phase is done/error)
+    insert_test_session(db, "old_done_1", "done", hours_ago=12)
+    insert_test_session(db, "old_error_1", "error", hours_ago=15)
+
+    # Recent non-terminal session: should NOT be deleted (fresh heartbeat)
+    insert_test_session(db, "recent_active_1", "planning", hours_ago=1)
+
+    print(f"Initial sessions: {count_sessions(db)}")
+    print(f"Initial heartbeats: {count_heartbeats(db)}")
+
+    # Run stuck cleanup with 6-hour threshold
+    result = db.cleanup_stuck_sessions(max_stale_hours=6)
+
+    print(f"\nCleanup result: {result}")
+    print(f"Remaining sessions: {count_sessions(db)}")
+    print(f"Remaining heartbeats: {count_heartbeats(db)}")
+
+    # Only stuck_1 and stuck_2 should be removed
+    assert result["sessions_deleted"] == 2, f"Expected 2 sessions deleted, got {result['sessions_deleted']}"
+    assert result["heartbeats_deleted"] == 2, f"Expected 2 heartbeats deleted, got {result['heartbeats_deleted']}"
+    assert len(result["session_ids"]) == 2, f"Expected 2 session IDs in result"
+    assert count_sessions(db) == 3, f"Expected 3 remaining sessions, got {count_sessions(db)}"
+    assert count_heartbeats(db) == 3, f"Expected 3 remaining heartbeats, got {count_heartbeats(db)}"
+
+    print("✓ Test passed!")
+
+
+def test_cleanup_stuck_sessions_none_found():
+    """Test cleanup_stuck_sessions when no stuck sessions exist."""
+    print("\n=== Test: cleanup_stuck_sessions (none found) ===")
+
+    db = setup_test_db()
+
+    # All sessions are either recent or terminal
+    insert_test_session(db, "recent_1", "planning", hours_ago=1)
+    insert_test_session(db, "done_1", "done", hours_ago=10)
+
+    print(f"Initial sessions: {count_sessions(db)}")
+
+    result = db.cleanup_stuck_sessions(max_stale_hours=6)
+
+    print(f"Cleanup result: {result}")
+
+    assert result["sessions_deleted"] == 0, f"Expected 0 sessions deleted, got {result['sessions_deleted']}"
+    assert result["heartbeats_deleted"] == 0, f"Expected 0 heartbeats deleted, got {result['heartbeats_deleted']}"
+    assert result["session_ids"] == [], f"Expected empty session_ids list"
+    assert count_sessions(db) == 2, f"Expected 2 remaining sessions, got {count_sessions(db)}"
+
+    print("✓ Test passed!")
+
+
 def test_cleanup_custom_threshold():
     """Test cleanup with custom age threshold."""
     print("\n=== Test: cleanup with custom threshold ===")
@@ -243,6 +304,8 @@ if __name__ == "__main__":
         test_clear_completed_sessions()
         test_cleanup_no_sessions()
         test_cleanup_custom_threshold()
+        test_cleanup_stuck_sessions()
+        test_cleanup_stuck_sessions_none_found()
 
         print("\n" + "=" * 50)
         print("All tests passed! ✓")


### PR DESCRIPTION
## Summary

Fixes the gap where stuck/incomplete sessions were never automatically cleaned up — only completed sessions were deleted, leaving the dashboard cluttered with orphaned sessions from interrupted pipeline runs.

## Changes

### `dashboard/backend.py`
- `cleanup_stuck_sessions(max_stale_hours=6)` — deletes sessions with no heartbeat in N hours that are not in a terminal phase (done/error)
- `DELETE /api/sessions/stuck?max_stale_hours=6` — new endpoint for manual cleanup
- `periodic_cleanup()` now also calls `cleanup_stuck_sessions(max_stale_hours=4)` every 6 hours

### `dashboard/frontend/index.html`
- **"Clear Stuck Sessions"** button next to existing "Clear Completed Sessions"
- **STALE badge** on session cards idle >2 hours in a non-terminal phase
- Toast notification on cleanup completion

### `tests/test_dashboard_cleanup.py`
- `test_cleanup_stuck_sessions()` — verifies old non-terminal sessions are deleted, terminal/recent ones preserved
- `test_cleanup_stuck_sessions_none_found()` — verifies zero-deletion return when nothing is stuck

## Tests
6/6 cleanup tests passed