### PR TITLE
docs: update documentation for terminal output, dashboard improvements, and publish pipeline

### DIFF
--- a/docs/user-guide/01-getting-started/configuration.md
+++ b/docs/user-guide/01-getting-started/configuration.md
@@ -95,26 +95,38 @@ API_TIMEOUT=120
 
 ### GitHub Integration
 
-Required for fetching upstream PR metadata linked to Jira tickets.
+Required for fetching upstream PR metadata linked to Jira tickets. `GITHUB_TOKEN` and `TARGET_GITHUB_REPO` are also used by `scripts/publish.py` to push generated code as a pull request.
 
-| Variable                  | Required | Default | Description                                                                                                   |
-|---------------------------|----------|---------|---------------------------------------------------------------------------------------------------------------|
-| `GITHUB_TOKEN`            | Optional | (none)  | Personal access token for reading GitHub PR data. Without it, PR URLs are shown but metadata is not fetched. |
-| `GITHUB_REQUEST_TIMEOUT`  | Optional | `10`    | Timeout in seconds for GitHub API requests                                                                    |
+| Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `GITHUB_TOKEN` | Optional | (none) | Personal access token for GitHub PR data. Required by `publish.py --push-code`. |
+| `GITHUB_REQUEST_TIMEOUT` | Optional | `10` | Timeout in seconds for GitHub API requests. |
+| `TARGET_GITHUB_REPO` | Optional | (none) | Target repository for `publish.py --push-code`, in `org/repo` format. |
+| `TARGET_GITHUB_BASE_BRANCH` | Optional | `main` | Base branch in the target repository that the generated PR targets. |
+| `QODO_API_KEY` | Optional | (none) | API key for Qodo code review. If not set, Qodo falls back to OAuth authentication. |
 
 ```bash
 # GitHub Integration (optional — enriches docs agent with upstream PR context)
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 GITHUB_REQUEST_TIMEOUT=10
+
+# Required by publish.py --push-code
+TARGET_GITHUB_REPO=openshift-builds/builds
+TARGET_GITHUB_BASE_BRANCH=main
+
+# Optional — Qodo code review
+QODO_API_KEY=your-qodo-api-key
 ```
 
-To create a token: GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens. Required scope: `Contents` (read-only) on the target repositories.
+To create a `GITHUB_TOKEN`: GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens. Required scope: `Contents` (read-only) on the target repositories. For `publish.py --push-code`, the token also needs `Contents` (write) permission on the target repository.
 
 ### Privacy and Security
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| -------- | ------- | ----------- |
 | `PII_REDACTION_ENABLED` | `true` | Redact PII from Jira and GitHub data before it enters the agent pipeline. Set to `false` only for local development — never in production. |
+| `PROMPT_GUARD_ENABLED` | `true` | Sanitize external text for prompt injection patterns before assembling agent prompts. Set to `false` only for local development — never in production. |
+| `OUTPUT_SANITIZER_ENABLED` | `true` | Enable the output sanitizer that checks agent responses before they are written to disk or returned to the caller. Set to `false` only for local development. |
 
 See [PII Redaction](../07-security/pii-redaction.md) for details on what is redacted and how the public domain allowlist works.
 

--- a/docs/user-guide/01-getting-started/quick-start.md
+++ b/docs/user-guide/01-getting-started/quick-start.md
@@ -26,6 +26,17 @@ uv run python scripts/orchestrate.py \
   --description "Users need ability to specify build timeout to prevent hanging builds"
 ```
 
+To save artifacts to a local directory, add `--output-dir`:
+
+```bash
+uv run python scripts/orchestrate.py \
+  --title "Add timeout support to BuildRun" \
+  --description "Users need ability to specify build timeout to prevent hanging builds" \
+  --output-dir ./my-output
+```
+
+The directory is created if it does not exist. Artifacts saved include `state.json`, generated code under `code/`, tests under `tests/`, design analysis under `design/`, and documentation under `docs/`. The `--output-dir` path is required by `scripts/publish.py` when pushing artifacts to GitHub or Jira.
+
 ### What Happens
 
 The workflow runs through five sequential phases:
@@ -42,6 +53,27 @@ State transitions:
 ```
 init → design_complete → develop_complete → review_complete → testing_complete → done
 ```
+
+While the workflow runs, the terminal prints a header for each phase showing its position in the sequence and a per-phase timer:
+
+```text
+Phase 1/5 · Design
+Phase 2/5 · Development
+Phase 3/5 · Code Review
+Phase 4/5 · Testing
+Phase 5/5 · Documentation
+```
+
+When all phases finish, a summary block is printed:
+
+```text
+Run complete
+  Duration:   3m 42s
+  Artifacts:  ./my-output
+  Dashboard:  http://localhost:8080
+```
+
+The dashboard URL is omitted if `DASHBOARD_ENABLED` is set to `false`.
 
 If an agent raises an unhandled exception, the workflow sets `current_phase = "error"` and stops early. The final state contains the error message.
 

--- a/docs/user-guide/02-concepts/architecture.md
+++ b/docs/user-guide/02-concepts/architecture.md
@@ -251,6 +251,36 @@ See [Claude Hooks](../07-security/claude-hooks.md) for the full reference, inclu
 
 ---
 
+## Terminal Output
+
+When you run the pipeline via `scripts/orchestrate.py`, each phase prints a numbered header so you can track progress at a glance. After every phase completes, the elapsed time for that phase is printed. When all phases finish, a summary is printed containing the total duration, the path to the saved output artifacts, and the dashboard URL.
+
+**Phase headers:**
+
+```text
+Phase 1/5 · Design
+Phase 2/5 · Development
+Phase 2.5/5 · Code Review
+Phase 3/5 · Testing
+Phase 4/5 · Documentation
+```
+
+**Per-phase completion line (example):**
+
+```text
+Design completed in 45.2s
+```
+
+**Final summary (example):**
+
+```text
+Pipeline completed in 3m 12s
+Artifacts: ./output/session-abc123/
+Dashboard: http://localhost:8080
+```
+
+---
+
 ## Supporting Components
 
 ### Dashboard

--- a/docs/user-guide/03-agents/docs-agent.md
+++ b/docs/user-guide/03-agents/docs-agent.md
@@ -15,6 +15,7 @@ The prompt instructs the agent to:
 
 - Only document what has been implemented and tested — never speculate
 - Produce a PR Summary (what changed, why, testing, rollout)
+- Always produce a full `## PR Description` section with a minimum of 300 words — this section is mandatory and must appear in every response
 - Generate release notes with category, title, description, and migration notes
 - Write Jobs-to-be-Done (JTBD) documentation organized around user outcomes
 - Produce SHIP format documents (Solution, Highlight, Impact, Plan) for stakeholder communication
@@ -70,6 +71,7 @@ To customize Documentation Agent behavior, edit `DOCS_AGENT_PROMPT` in `config/a
 {
     # Core documentation (all formats)
     "pr_summary": str,               # Pull request description
+    "pr_description": str,           # Full PR description (mandatory, 300-word minimum)
     "release_notes": str,            # User-facing changelog entry
     "docs_changes": dict[str, str],  # doc file path → change description
     "upgrade_notes": str,            # Migration guidance for existing users
@@ -235,8 +237,12 @@ result = run_docs(context=context, enable_rag=False)
 | Input file does not exist | File is skipped, generation continues |
 | RAG search failure | Warning logged, generation continues |
 | Missing required context keys | Raises `RuntimeError: Missing required context keys` |
+| `pr_description` key absent in parsed response | Parser retries with fallback keys: `pr description`, `pull request description`, `pr` (in that order) |
+| Extracted `pr_description` is under 100 characters | Warning logged indicating a likely parsing failure; check the raw model response for a malformed or missing `## PR Description` section |
 
 **Required context keys:** `design_analysis`, `code_changes`, `test_results`
+
+**`pr_description` parsing notes:** The agent prompt enforces a mandatory `## PR Description` section with a 300-word minimum. The parser first looks for a `pr_description` key in the structured response; if that key is absent it falls back to `pr description`, then `pull request description`, then `pr`. A warning is logged when the final extracted value is shorter than 100 characters, which typically indicates the section was missing or malformed in the model response.
 
 ---
 

--- a/docs/user-guide/04-dashboard/overview.md
+++ b/docs/user-guide/04-dashboard/overview.md
@@ -64,24 +64,65 @@ Session abc123
 Issue: Add timeout support to BuildRun
 Type: feature
 
-Design Agent     Complete
-Development      Complete
-Testing          In Progress
-Documentation    Waiting
+[ Design ] --> [ Dev ] --> [ Review ] --> [ Testing ] --> [ Docs ]
+  done           done        active         pending        pending
+
+Tests: 12 unit / 4 integration / 2 e2e
+Code files: 6    Artifacts: /tmp/claude/sessions/abc123/
+Review: PASS
+
+Started: 2026-03-26 14:00:00    Last updated: 2s ago
 
 Context: 64%
 Model: claude-sonnet-4
-Last update: 2s ago
 ```
 
-### Key Metrics
+### Session Card Layout
+
+Each session card displays the following fields:
+
+**Phase timeline strip**
+A row of five phase bubbles — Design, Dev, Review, Testing, Docs — shown in order. Each bubble carries one of three states:
+
+- `done` — the phase completed successfully
+- `active` — the phase is currently running
+- `pending` — the phase has not started yet
+
+The timeline gives an at-a-glance view of where the workflow is without reading individual status labels.
+
+**Test counts**
+Unit, integration, and end-to-end test counts produced by the Testing agent. Displayed as `N unit / N integration / N e2e`. These values are populated once the testing phase completes.
+
+**Code files count**
+The number of code files generated or modified by the Development agent.
+
+**Artifact path link**
+A clickable path to the session output directory on disk. Use this to locate generated code, test files, and documentation artifacts.
+
+**Review badge**
+A `PASS` or `FAIL` badge from the Code Review agent. A `FAIL` badge indicates the auto-fix loop is still iterating or that review did not pass before the workflow ended.
+
+**Dual timestamps**
+
+- **Started** — when the session was first created (first heartbeat received)
+- **Last updated** — time elapsed since the most recent heartbeat
+
+**Context and model**
+Context window usage percentage and the Claude model name in use.
+
+**Risks**
+If the Design agent identified risks, they are rendered directly in the card for quick reference.
+
+### Key Metrics and What to Monitor
 
 | Metric | What to watch for |
 |--------|-------------------|
-| **Context percentage** | Monitor for >80% - agent may run out of space before completing |
-| **Phase progression** | Confirms workflow is advancing (Design → Dev → Test → Docs → Done) |
+| **Phase timeline strip** | Check that bubbles progress left-to-right; a bubble stuck on `active` for a long time may indicate a hung agent |
+| **Context percentage** | Monitor for >80% — agent may run out of space before completing |
+| **Phase progression** | Confirms workflow is advancing (Design → Dev → Review → Test → Docs → Done) |
 | **Component impact** | Which parts of the Shipwright codebase are being analyzed |
-| **Last update** | If this stops updating, the agent may have hung or crashed |
+| **Last updated** | If this stops advancing, the agent may have hung or crashed |
+| **Review badge** | A persistent `FAIL` badge means the review loop did not converge — check agent logs |
 
 ---
 

--- a/docs/user-guide/04-dashboard/session-management.md
+++ b/docs/user-guide/04-dashboard/session-management.md
@@ -15,6 +15,15 @@ planning → executing → done
 
 Active sessions (any phase other than `done` or `error`) are never touched by cleanup operations.
 
+### Dual Timestamps
+
+Each session card in the UI shows two timestamps:
+
+- **Started** — when the first heartbeat for the session was received. This is the wall-clock time the workflow began.
+- **Last updated** — time elapsed since the most recent heartbeat. This value refreshes every 3 seconds while the dashboard is open.
+
+Use the gap between these two values to identify stuck sessions. If "Last updated" has not advanced for several minutes while the session is still in an active phase, the agent has likely hung or lost connectivity. See [Troubleshooting](#troubleshooting) for steps to investigate.
+
 ---
 
 ## Automatic Cleanup

--- a/docs/user-guide/06-advanced/code-flow.md
+++ b/docs/user-guide/06-advanced/code-flow.md
@@ -9,8 +9,8 @@ This document maps every major function call in the system, showing who calls wh
 The system has two entry points depending on how you invoke it:
 
 | Entry point | File | When used |
-|-------------|------|-----------|
-| `orchestrate()` | `scripts/orchestrate.py` | CLI invocation by a user or CI job. Runs each phase sequentially, calls validators between phases, and supports manual approval gates. |
+| --- | --- | --- |
+| `orchestrate()` | `scripts/orchestrate.py` | CLI invocation by a user or CI job. Runs each phase sequentially, calls validators between phases, and supports manual approval gates. Accepts `--output-dir <path>` to save all pipeline artifacts (JSON state, per-phase markdown files) to a local directory. |
 | `build_workflow()` | `agents/graph.py` | LangGraph pipeline invocation. Builds a `StateGraph` where nodes are the five agents and routing is driven by `state["current_phase"]`. Used when you want LangGraph to manage state and edges rather than imperative Python. |
 
 Both paths call the same five agent functions (`run_design`, `run_development`, `run_code_review`, `run_testing`, `run_docs`) and emit heartbeats to the dashboard after each phase.
@@ -133,6 +133,8 @@ orchestrate(title, description, repo_path, issue_type)
 - `validate_phase()` runs after each agent returns. If validation fails, `orchestrate()` raises an exception and halts the pipeline rather than passing bad data downstream.
 - `emit_heartbeat()` is called at least once per phase. The development agent calls it twice — once before the API call (to signal the phase has started) and once after (to signal completion with token counts).
 - `detect_patterns_in_description()` in the testing phase scans the issue description for keywords (build strategy names, source types) and injects matching Ginkgo v2 templates into the prompt.
+- Each phase prints a numbered header to the terminal when it starts (e.g., `Phase 1/5 · Design`, `Phase 2.5/5 · Code Review`) and prints its elapsed duration when it completes (e.g., `Design completed in 45.2s`).
+- After all phases finish, a final summary is printed containing the total pipeline duration, the path to saved output artifacts, and the dashboard URL. Pass `--output-dir <path>` to control where artifacts are written; without this flag, artifacts are not saved to disk.
 
 ---
 

--- a/docs/user-guide/09-integrations/publish.md
+++ b/docs/user-guide/09-integrations/publish.md
@@ -1,0 +1,224 @@
+# Publishing Artifacts
+
+After the pipeline finishes, use `scripts/publish.py` to push the generated artifacts to external systems. The script reads the output directory produced by `orchestrate.py` and can open a GitHub pull request with the generated code, post the design analysis and release notes back to Jira, or do both in a single run.
+
+---
+
+## Prerequisites
+
+Before running the publish script, confirm you have:
+
+- Completed at least one workflow run with `--output-dir` set, so the output directory exists and contains `state.json`
+- The GitHub CLI (`gh`) installed and authenticated — required for `--push-code`
+- The appropriate credentials in your `.env` file (see [Required Environment Variables](#required-environment-variables) below)
+
+---
+
+## Usage
+
+```bash
+uv run python scripts/publish.py --output-dir PATH [--push-code] [--push-jira] [--dry-run]
+```
+
+At least one of `--push-code` or `--push-jira` is required. The two flags can be combined in a single run.
+
+---
+
+## CLI Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--output-dir PATH` | Yes | Directory containing pipeline artifacts (must contain `state.json`) |
+| `--push-code` | No* | Push generated code and tests to the target GitHub repository as a PR |
+| `--push-jira` | No* | Attach design analysis and post PR summary and release notes back to the originating Jira ticket |
+| `--dry-run` | No | Print what would be done without making any API calls or git operations |
+
+*At least one of `--push-code` or `--push-jira` must be specified.
+
+---
+
+## Required Environment Variables
+
+### For `--push-code`
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GITHUB_TOKEN` | Yes | (none) | Personal access token with `Contents` (write) permission on the target repository |
+| `TARGET_GITHUB_REPO` | Yes | (none) | Target repository in `org/repo` format, e.g. `openshift-builds/builds` |
+| `TARGET_GITHUB_BASE_BRANCH` | No | `main` | The branch in the target repository that the generated PR targets |
+
+Add these to your `.env` file:
+
+```bash
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+TARGET_GITHUB_REPO=openshift-builds/builds
+TARGET_GITHUB_BASE_BRANCH=main
+```
+
+To create a `GITHUB_TOKEN`: GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens. The token needs `Contents` (write) permission on the target repository so the script can push the new branch.
+
+### For `--push-jira`
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `JIRA_BASE_URL` | Yes | Your Atlassian Cloud base URL, e.g. `https://your-org.atlassian.net` |
+| `JIRA_USER_EMAIL` | Yes | The email address tied to your Jira API token |
+| `JIRA_API_TOKEN` | Yes | Your Atlassian API token |
+
+Add these to your `.env` file:
+
+```bash
+JIRA_BASE_URL=https://your-org.atlassian.net
+JIRA_USER_EMAIL=your-email@company.com
+JIRA_API_TOKEN=your-api-token-here
+```
+
+`--push-jira` also requires that `state.json` contains a `jira_ticket_id` field. This field is populated automatically when the pipeline is started with `--jira-ticket`. If the field is absent, the script exits with an error.
+
+See [Jira & Rovo Integration](jira-rovo.md) for instructions on setting up Jira credentials and creating an API token.
+
+---
+
+## What Each Flag Does
+
+### `--push-code`
+
+Pushes the generated Go source files and test files to the target GitHub repository and opens a pull request.
+
+Steps performed:
+
+1. Reads `state.json` to extract the Jira ticket ID and issue title.
+2. Collects all files under `output-dir/code/` and `output-dir/tests/`.
+3. Shallow-clones `TARGET_GITHUB_REPO` into a temporary directory.
+4. Creates a new branch named `feat/<ticket-id>-<slug-of-title>` from `TARGET_GITHUB_BASE_BRANCH`.
+5. Copies code and test files to the repo root, preserving their relative paths.
+6. Commits and pushes the branch.
+7. Opens a PR using `docs/pr_description.md` from the output directory as the PR body. If that file is absent, a default body is generated.
+8. Prints the PR URL.
+9. Cleans up the temporary directory.
+
+The commit message follows the Conventional Commits format: `feat(<ticket-id>): <issue title>`, truncated to 72 characters if necessary.
+
+### `--push-jira`
+
+Uploads design and documentation artifacts back to the originating Jira ticket.
+
+Actions performed:
+
+1. Attaches `design/design_analysis.md` as a file attachment on the ticket.
+2. Posts the contents of `docs/pr_summary.md` as a ticket comment.
+3. Posts the contents of `docs/release_notes.md` as a ticket comment, if the file is non-empty.
+
+---
+
+## Example Usage
+
+**Preview what would happen without making any changes:**
+
+```bash
+uv run python scripts/publish.py \
+  --output-dir ./output/SHIP-456 \
+  --push-code \
+  --dry-run
+```
+
+**Open a GitHub PR from the generated artifacts:**
+
+```bash
+uv run python scripts/publish.py \
+  --output-dir ./output/SHIP-456 \
+  --push-code
+```
+
+**Upload artifacts back to the Jira ticket:**
+
+```bash
+uv run python scripts/publish.py \
+  --output-dir ./output/SHIP-456 \
+  --push-jira
+```
+
+**Do both in a single run:**
+
+```bash
+uv run python scripts/publish.py \
+  --output-dir ./output/SHIP-456 \
+  --push-code \
+  --push-jira
+```
+
+---
+
+## Output Directory Layout
+
+`publish.py` expects the output directory to have been produced by `orchestrate.py --output-dir`. The relevant files it reads are:
+
+```text
+output/SHIP-456/
+  state.json              ← required by both --push-code and --push-jira
+  code/                   ← read by --push-code
+  tests/                  ← read by --push-code
+  design/
+    design_analysis.md    ← attached to Jira by --push-jira
+  docs/
+    pr_description.md     ← used as GitHub PR body by --push-code
+    pr_summary.md         ← posted as Jira comment by --push-jira
+    release_notes.md      ← posted as Jira comment by --push-jira (if non-empty)
+```
+
+Files that are missing are skipped with a warning rather than causing a hard failure, except for `state.json` which is required and causes an immediate exit if absent.
+
+---
+
+## Dry-Run Mode
+
+Add `--dry-run` to any invocation to print what would be done without making API calls, creating branches, or modifying any external system.
+
+```bash
+uv run python scripts/publish.py \
+  --output-dir ./output/SHIP-456 \
+  --push-code \
+  --push-jira \
+  --dry-run
+```
+
+Sample output:
+
+```text
+-- push-code -------------------------------------------------------
+  Target repo:   openshift-builds/builds
+  Base branch:   main
+  New branch:    feat/ship-456-add-timeout-support-to-buildrun
+  Commit msg:    feat(SHIP-456): Add timeout support to BuildRun
+  Code files:    4
+  Test files:    2
+
+  [dry-run] Would clone, copy files, commit, push, and open a PR.
+  [dry-run] Branch:  feat/ship-456-add-timeout-support-to-buildrun
+  [dry-run] Commit:  feat(SHIP-456): Add timeout support to BuildRun
+  [dry-run] Repo:    https://github.com/openshift-builds/builds
+
+-- push-jira -------------------------------------------------------
+  Ticket: SHIP-456
+  [dry-run] Would attach design/design_analysis.md to SHIP-456
+  [dry-run] Would post PR summary comment to SHIP-456
+  [dry-run] Would post release notes comment to SHIP-456
+```
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `state.json not found` | `--output-dir` does not contain a completed pipeline run | Run `orchestrate.py --output-dir PATH` first |
+| `TARGET_GITHUB_REPO is not set` | Missing environment variable | Add `TARGET_GITHUB_REPO=org/repo` to `.env` |
+| `GITHUB_TOKEN is not set` | Missing environment variable | Add `GITHUB_TOKEN=ghp_...` to `.env` |
+| `git push failed — branch may already exist` | A branch with the same name was pushed previously | Delete the remote branch and retry, or rerun the pipeline to generate a new branch name |
+| `Missing required environment variable(s): JIRA_BASE_URL, ...` | One or more Jira variables absent | Add the missing variables to `.env` |
+| `jira_ticket_id not found in state.json` | Pipeline was not started with `--jira-ticket` | Re-run `orchestrate.py` with `--jira-ticket TICKET-ID --output-dir PATH` |
+| `Failed to attach design_analysis.md (HTTP 401/403)` | Jira credentials are wrong or expired | Verify `JIRA_USER_EMAIL` and `JIRA_API_TOKEN` in `.env`; regenerate the token if needed |
+
+---
+
+[← Previous: Jira & Rovo Integration](jira-rovo.md) | [Back to Index →](../README.md)

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -84,9 +84,10 @@ This system automates the design, development, testing, and documentation workfl
 
 ### Section 9 - Integrations
 
-| Page | Description |
-|------|-------------|
-| [Jira & Rovo](09-integrations/jira-rovo.md) | Feed Jira tickets directly to the agent pipeline; Rovo MCP setup |
+| Page                                                               | Description                                                                       |
+|--------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| [Jira & Rovo](09-integrations/jira-rovo.md)                        | Feed Jira tickets directly to the agent pipeline; Rovo MCP setup                  |
+| [Publishing Artifacts (`publish.py`)](09-integrations/publish.md)  | Push generated code, docs, and summaries to GitHub or Jira                        |
 
 ---
 
@@ -105,6 +106,7 @@ This system automates the design, development, testing, and documentation workfl
 | Debug a failing workflow | [Troubleshooting](06-advanced/troubleshooting.md) |
 | Understand how state flows between agents | [State Management](02-concepts/state-management.md) |
 | Use a Jira ticket as workflow input | [Jira & Rovo Integration](09-integrations/jira-rovo.md) |
+| Publish code/docs to GitHub or Jira | [Publishing Artifacts](09-integrations/publish.md) |
 | Review generated code automatically | [Code Review Agent](03-agents/code-review-agent.md) |
 
 ---


### PR DESCRIPTION
## Summary

- **Dashboard docs**: Added session card layout section (phase timeline strip, test count metrics, review badge, dual timestamps, artifact path link) to `overview.md`; added dual timestamps guidance for stuck session detection to `session-management.md`
- **Docs agent**: Documented mandatory `pr_description` output (300-word minimum), fallback key matching (`pr description` / `pull request description` / `pr`), and short-description warning log
- **Architecture & code-flow**: Added terminal output section (Phase X/5 headers, per-phase timing, final summary block); updated orchestrate flow to reflect Phase 2.5 Code Review and `--output-dir` flag
- **Getting started**: Added `--output-dir` usage examples to `quick-start.md`; added `QODO_API_KEY`, `PROMPT_GUARD_ENABLED`, `OUTPUT_SANITIZER_ENABLED` to `configuration.md`
- **New**: `09-integrations/publish.md` — full reference for `scripts/publish.py` (`--push-code`, `--push-jira`, `--dry-run`, env vars, examples, troubleshooting)
- **README**: Added publish integration to nav table and quick-reference use case table

## Test plan
- [ ] Review each updated doc section for accuracy against the source code
- [ ] Verify links in `README.md` resolve correctly (especially the new `publish.md` link)
- [ ] Confirm `publish.md` env var table matches `scripts/publish.py` requirements