### PR TITLE
fix(docs): simplify dashboard startup command across all docs

### DIFF
--- a/docs/user-guide/01-getting-started/quick-start.md
+++ b/docs/user-guide/01-getting-started/quick-start.md
@@ -123,7 +123,7 @@ Start the dashboard before running the orchestrator to watch each agent's progre
 **Terminal 1 - Start the dashboard:**
 
 ```bash
-uv run --with fastapi --with "uvicorn[standard]" --with requests python scripts/run_dashboard.py
+uv run python scripts/run_dashboard.py
 ```
 
 Open http://localhost:8080 in your browser.

--- a/docs/user-guide/04-dashboard/overview.md
+++ b/docs/user-guide/04-dashboard/overview.md
@@ -44,7 +44,7 @@ The dashboard provides real-time visibility into agent workflows. It shows which
 ## Starting the Dashboard
 
 ```bash
-uv run --with fastapi --with "uvicorn[standard]" --with requests python scripts/run_dashboard.py
+uv run python scripts/run_dashboard.py
 ```
 
 | Endpoint | URL |
@@ -174,7 +174,7 @@ logs/
 
 ```bash
 # Terminal 1: start the dashboard
-uv run --with fastapi --with "uvicorn[standard]" --with requests python scripts/run_dashboard.py
+uv run python scripts/run_dashboard.py
 
 # Terminal 2: run the workflow
 uv run python scripts/orchestrate.py \

--- a/docs/user-guide/06-advanced/dry-run-mode.md
+++ b/docs/user-guide/06-advanced/dry-run-mode.md
@@ -156,7 +156,7 @@ With a live dashboard:
 
 ```bash
 # Terminal 1: start the dashboard
-uv run --with fastapi --with "uvicorn[standard]" --with requests python scripts/run_dashboard.py
+uv run python scripts/run_dashboard.py
 
 # Terminal 2: run dashboard tests
 uv run python scripts/test_agents.py --dashboard --debug

--- a/docs/user-guide/07-examples/README.md
+++ b/docs/user-guide/07-examples/README.md
@@ -285,7 +285,7 @@ The dashboard backend must be running before you execute this script:
 
 ```bash
 # Terminal 1: Start the dashboard
-uv run --with fastapi --with "uvicorn[standard]" --with requests python scripts/run_dashboard.py
+uv run python scripts/run_dashboard.py
 ```
 
 ### How to Run

--- a/docs/user-guide/09-integrations/jira-rovo.md
+++ b/docs/user-guide/09-integrations/jira-rovo.md
@@ -98,7 +98,7 @@ Start the dashboard before running the orchestrator:
 
 ```bash
 # Terminal 1
-uv run --with fastapi --with "uvicorn[standard]" --with requests python scripts/run_dashboard.py
+uv run python scripts/run_dashboard.py
 
 # Terminal 2
 uv run python scripts/orchestrate.py --jira-ticket SHIP-123


### PR DESCRIPTION
## Summary

Replaces the verbose inline dependency form with the simple form that matches `CLAUDE.md`:

**Before:**
\`\`\`bash
uv run --with fastapi --with "uvicorn[standard]" --with requests python scripts/run_dashboard.py
\`\`\`

**After:**
\`\`\`bash
uv run python scripts/run_dashboard.py
\`\`\`

Updated 5 files (6 occurrences total):
- `docs/user-guide/04-dashboard/overview.md`
- `docs/user-guide/01-getting-started/quick-start.md`
- `docs/user-guide/09-integrations/jira-rovo.md`
- `docs/user-guide/06-advanced/dry-run-mode.md`
- `docs/user-guide/07-examples/README.md`

## Test plan
- [ ] Verify `uv run python scripts/run_dashboard.py` works after `uv pip install -r requirements.txt`