### PR TITLE
fix(docs): add --jira-ticket and --output-dir to all orchestrate.py examples

### DIFF
--- a/docs/user-guide/03-agents/code-review-agent.md
+++ b/docs/user-guide/03-agents/code-review-agent.md
@@ -161,7 +161,8 @@ To skip the code review phase entirely, set `QODO_REVIEW_ENABLED=false`:
 ```bash
 QODO_REVIEW_ENABLED=false uv run python scripts/orchestrate.py \
   --title "Quick feature" \
-  --description "Simple change"
+  --description "Simple change" \
+  --output-dir ./output
 ```
 
 When disabled, the pipeline routes directly from Development to Testing with no review state written.
@@ -174,11 +175,16 @@ In dry-run mode, the agent does not call the Claude API or the Qodo CLI. It read
 
 ```bash
 # Simulate a passing review (default dry-run behavior)
-uv run python scripts/orchestrate.py --jira-ticket SHIP-123 --dry-run
+uv run python scripts/orchestrate.py \
+  --jira-ticket SHIP-123 \
+  --output-dir ./output \
+  --dry-run
 
 # Simulate a blocking review (triggers mock auto-fix loop)
 MOCK_CODE_REVIEW_PASS=false uv run python scripts/orchestrate.py \
-  --jira-ticket SHIP-123 --dry-run
+  --jira-ticket SHIP-123 \
+  --output-dir ./output \
+  --dry-run
 ```
 
 ---

--- a/docs/user-guide/04-dashboard/overview.md
+++ b/docs/user-guide/04-dashboard/overview.md
@@ -177,9 +177,16 @@ logs/
 uv run --with fastapi --with "uvicorn[standard]" --with requests python scripts/run_dashboard.py
 
 # Terminal 2: run the workflow
+# From a Jira ticket
+uv run python scripts/orchestrate.py \
+  --jira-ticket SHIP-123 \
+  --output-dir ./output
+
+# Or from a title and description
 uv run python scripts/orchestrate.py \
   --title "Add timeout support to BuildRun" \
-  --description "Users need ability to specify build timeout to prevent hanging builds"
+  --description "Users need ability to specify build timeout to prevent hanging builds" \
+  --output-dir ./output
 ```
 
 The session appears in the dashboard within seconds of the workflow starting.

--- a/docs/user-guide/06-advanced/logging.md
+++ b/docs/user-guide/06-advanced/logging.md
@@ -132,7 +132,10 @@ Set `LOG_FORMAT=json` for structured log output compatible with log aggregation 
 Set `LOG_LEVEL=DEBUG` in `.env`, then run:
 
 ```bash
-uv run python scripts/orchestrate.py --title "Test" --description "Debug run"
+uv run python scripts/orchestrate.py \
+  --title "Test" \
+  --description "Debug run" \
+  --output-dir ./output
 tail -f /tmp/muilti-agents-debug.log
 ```
 

--- a/docs/user-guide/06-advanced/output-validation.md
+++ b/docs/user-guide/06-advanced/output-validation.md
@@ -174,7 +174,8 @@ Or pass it inline for a single run:
 ```bash
 MANUAL_APPROVAL=true uv run python scripts/orchestrate.py \
   --title "Add SSH key support for private Git repos" \
-  --description "Users need to build from private Git repos using SSH authentication"
+  --description "Users need to build from private Git repos using SSH authentication" \
+  --output-dir ./output
 ```
 
 ### What It Looks Like
@@ -238,7 +239,8 @@ This is the right mode for CI/CD pipelines and unattended runs where you want au
 # Auto mode (default - no changes needed)
 uv run python scripts/orchestrate.py \
   --title "Add SSH key support for private Git repos" \
-  --description "Users need to build from private Git repos using SSH authentication"
+  --description "Users need to build from private Git repos using SSH authentication" \
+  --output-dir ./output
 ```
 
 ---

--- a/docs/user-guide/06-advanced/troubleshooting.md
+++ b/docs/user-guide/06-advanced/troubleshooting.md
@@ -256,7 +256,10 @@ LOG_FILE_PATH=/tmp/muilti-agents-debug.log
 Then run and follow the log:
 
 ```bash
-uv run python scripts/orchestrate.py --title "Test" --description "Debug run"
+uv run python scripts/orchestrate.py \
+  --title "Test" \
+  --description "Debug run" \
+  --output-dir ./output
 tail -f /tmp/muilti-agents-debug.log
 ```
 

--- a/docs/user-guide/07-examples/README.md
+++ b/docs/user-guide/07-examples/README.md
@@ -397,7 +397,8 @@ Set `QODO_REVIEW_ENABLED=false` to skip the Code Review phase entirely. The pipe
 ```bash
 QODO_REVIEW_ENABLED=false uv run python scripts/orchestrate.py \
   --title "Feature title" \
-  --description "Description"
+  --description "Description" \
+  --output-dir ./output
 ```
 
 ### c) Tuning the Auto-fix Loop
@@ -413,7 +414,8 @@ QODO_REVIEW_ENABLED=false uv run python scripts/orchestrate.py \
 ```bash
 MAX_REVIEW_ITERATIONS=5 QODO_BLOCKING_THRESHOLD=medium uv run python scripts/orchestrate.py \
   --title "Add timeout support" \
-  --description "Users need configurable timeouts"
+  --description "Users need configurable timeouts" \
+  --output-dir ./output
 ```
 
 ### d) Optional Qodo CLI
@@ -423,7 +425,8 @@ Set `QODO_CLI_PATH` to the absolute path of the Qodo binary to use Qodo as the r
 ```bash
 QODO_CLI_PATH=/usr/local/bin/qodo uv run python scripts/orchestrate.py \
   --title "Add timeout support" \
-  --description "Description"
+  --description "Description" \
+  --output-dir ./output
 ```
 
 ### e) Reading Review Output from State


### PR DESCRIPTION
## Summary

Ensures every `orchestrate.py` command example in the docs shows `--jira-ticket` and/or `--output-dir` so users know these options exist.

**Updated files (6):**
- `docs/user-guide/04-dashboard/overview.md` — split into jira-ticket and title/description variants, both with `--output-dir`
- `docs/user-guide/06-advanced/output-validation.md` — added `--output-dir` to both examples
- `docs/user-guide/06-advanced/logging.md` — added `--output-dir` to debug example
- `docs/user-guide/06-advanced/troubleshooting.md` — added `--output-dir` to debug example
- `docs/user-guide/07-examples/README.md` — added `--output-dir` to all three code review examples
- `docs/user-guide/03-agents/code-review-agent.md` — added `--output-dir` to all three examples

## Test plan
- [ ] Spot-check that commands in updated files are syntactically correct