### PR TITLE
fix(orchestrate): add sys.path insert to resolve agents module

### DIFF
--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -17,6 +17,8 @@ from dotenv import load_dotenv, find_dotenv
 
 load_dotenv(find_dotenv())
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 MANUAL_APPROVAL = os.getenv("MANUAL_APPROVAL", "false").lower() == "true"
 
 from agents.validators import validate_phase


### PR DESCRIPTION
## Summary

`scripts/orchestrate.py` was missing the `sys.path` insert that `run_dashboard.py` and `test_agents.py` already have. Because `pyproject.toml` sets `package = false`, the project root is never added to `sys.path` by `uv`, causing `ModuleNotFoundError: No module named 'agents'` on startup.

**Fix:** Added before the first project-level import:
\`\`\`python
sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
\`\`\`

## Test plan
- [x] `uv run python scripts/orchestrate.py --help` runs without error