### PR TITLE
feat(orchestrate): add --debug flag to enable DEBUG log level

### DIFF
--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -536,7 +536,15 @@ Examples:
         metavar="PATH",
         help="Save all pipeline artifacts to this directory after completion.",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging.",
+    )
     args = parser.parse_args()
+
+    if args.debug:
+        os.environ["LOG_LEVEL"] = "DEBUG"
 
     if not args.jira_ticket and not args.title:
         parser.error("either --title or --jira-ticket is required")

--- a/utils/file_logger.py
+++ b/utils/file_logger.py
@@ -23,7 +23,7 @@ LOGS_DIR = Path(__file__).parent.parent / "logs"
 def get_logger(
     name: str,
     log_file: Optional[str] = None,
-    level: int = logging.INFO,
+    level: int = getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO),
     console_output: bool = True,
     file_output: bool = True,
 ) -> logging.Logger:


### PR DESCRIPTION
Adds --debug as a store_true CLI flag. When set, LOG_LEVEL=DEBUG is injected before agent imports so all loggers pick it up. Also updates utils/file_logger.py to read LOG_LEVEL from env at logger creation time.