### PR TITLE
fix: artifact save crash and pr_summary empty from docs agent

### DIFF
--- a/config/agent_prompts.py
+++ b/config/agent_prompts.py
@@ -218,30 +218,30 @@ ensuring accuracy and completeness.
 
 When creating documentation, produce the following sections:
 
-### PR Summary
+## PR Summary
 - **What changed** - Brief description of the change
 - **Why** - Motivation and context
 - **Testing** - How it was validated
 - **Rollout** - Any special deployment considerations
 
-### User-Facing Documentation Changes
+## User-Facing Documentation Changes
 - **Affected docs** - List of documentation files to update
 - **New content** - New sections to add (in Markdown)
 - **Updated content** - Sections to modify (with diffs)
 - **Examples** - Complete, working examples
 
-### Release Note
+## Release Note
 - **Category** - bug fix, feature, enhancement, deprecation, breaking change
 - **Title** - User-facing one-liner
 - **Description** - 2-3 sentences explaining the change
 - **Migration note** - (if breaking) Steps to adapt
 
-### Upgrade Note
+## Upgrade Note
 - **Affected versions** - Which versions does this apply to
 - **Action required** - What users must do (if any)
 - **Recommended** - What users should do (optional improvements)
 
-### Known Limitations
+## Known Limitations
 - Any edge cases not yet supported
 - Planned future work
 - Workarounds for known issues

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -132,8 +132,14 @@ def _save_artifacts(state: dict, output_dir: str) -> pathlib.Path:
         _write(pathlib.Path("design") / "implementation_plan.md", lines)
 
     # code/<original_path>  — support both code_files and code_changes keys
-    code_dict: dict = state.get("code_files") or state.get("code_changes") or {}
-    for file_path, content in code_dict.items():
+    # code_files from development agent is a list of dicts with "path"/"content" keys;
+    # code_changes may be a plain dict mapping path→content.
+    code_raw = state.get("code_files") or state.get("code_changes") or {}
+    if isinstance(code_raw, list):
+        code_items = ((item["path"], item.get("content", "")) for item in code_raw)
+    else:
+        code_items = code_raw.items()
+    for file_path, content in code_items:
         if content:
             target = (root / "code" / file_path).resolve()
             if not str(target).startswith(str(root.resolve()) + os.sep):


### PR DESCRIPTION
## Fixes

### 1. `_save_artifacts` crash — `AttributeError: 'list' object has no attribute 'items'`
`code_files` from the development agent is a list of `{path, content}` dicts, not a plain dict. Fixed iteration in `_save_artifacts` to handle both list and dict formats.

### 2. `pr_summary` always empty from docs agent
`DOCS_AGENT_PROMPT` instructed Claude to emit `### PR Summary` and related output sections with level-3 headers, but `_split_into_sections()` only recognises level-2 (`##`) headers as section boundaries. Promoted all five top-level output section headers from `###` to `##`:
- `## PR Summary`
- `## User-Facing Documentation Changes`
- `## Release Note`
- `## Upgrade Note`
- `## Known Limitations`

## Test plan
- [x] Pipeline ran to completion (all 5 phases)
- [ ] Re-run pipeline and verify `pr_summary` is populated
- [ ] Verify artifacts save correctly without crash