### PR TITLE
fix(dashboard): show session card immediately at pipeline start

### DIFF
--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -243,9 +243,10 @@ def orchestrate(
     # Propagate orchestrator session_id to the global heartbeat emitter so all
     # emit_heartbeat() calls use the same session throughout the pipeline.
     try:
-        from dashboard.heartbeat import get_global_emitter
+        from dashboard.heartbeat import get_global_emitter, emit_heartbeat
         emitter = get_global_emitter()
         emitter.session_id = session_id
+        emit_heartbeat("orchestrator", state)  # show card immediately on dashboard
     except Exception:
         pass  # dashboard unavailable, non-blocking
 


### PR DESCRIPTION
## Problem

The session card only appeared in the dashboard after the Design phase completed (~90s into the run), because the first heartbeat was emitted after `run_design()` returned.

## Fix

Added `emit_heartbeat("orchestrator", state)` immediately after the session is initialized (before any agent runs). The state at this point contains `session_id` and `current_phase: "init"`, which is enough for the dashboard to render the card right away.

## Result

Session card appears on the dashboard as soon as the pipeline starts.