### PR TITLE
fix(testing): fix doubled test output path (tests/unit/test/unit/...)

### DIFF
--- a/agents/testing_agent.py
+++ b/agents/testing_agent.py
@@ -8,6 +8,7 @@ output types), and generates structured test plans along with working Ginkgo v2 
 """
 
 import os
+import re
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 
@@ -672,7 +673,8 @@ def _write_test_plan_md(output: Dict[str, Any], output_dir: Path) -> None:
         all_test_files: list = []
         for section, subdir in section_subdirs.items():
             for path in output.get(section, {}).keys():
-                all_test_files.append(f"- `{subdir}/{path}`")
+                clean_path = _strip_test_category_prefix(path)
+                all_test_files.append(f"- `{subdir}/{clean_path}`")
 
         patterns = output.get("patterns_detected", {})
         strategies = patterns.get("strategies", [])
@@ -714,6 +716,11 @@ def _write_test_plan_md(output: Dict[str, Any], output_dir: Path) -> None:
         logger.error(f"Failed to write test_plan.md: {e}")
 
 
+def _strip_test_category_prefix(path: str) -> str:
+    """Remove leading test category prefix from Claude-generated paths."""
+    return re.sub(r'^test/(unit|integration|e2e|e2e_tests)/', '', path)
+
+
 def _write_go_test_files(output: Dict[str, Any], output_dir: Path) -> None:
     """Write Go test files to tests/unit, tests/integration, tests/e2e under output_dir."""
     section_dirs = {
@@ -728,7 +735,8 @@ def _write_go_test_files(output: Dict[str, Any], output_dir: Path) -> None:
         for full_path, code in files.items():
             if not code:
                 continue
-            dest = dest_dir / full_path
+            clean_path = _strip_test_category_prefix(full_path)
+            dest = dest_dir / clean_path
             dest.parent.mkdir(parents=True, exist_ok=True)
             safe_code = sanitize(code, source=f"testing_agent:go_test:{dest.name}")
             dest.write_text(safe_code, encoding="utf-8")

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -8,6 +8,7 @@ Set MANUAL_APPROVAL=true in .env to pause for user approval between phases.
 import json
 import os
 import pathlib
+import re
 import sys
 import time
 import uuid
@@ -110,6 +111,12 @@ def _save_artifacts(state: dict, output_dir: str) -> pathlib.Path:
     if root.exists() and any(root.iterdir()):
         print(f"  WARNING: Output directory already exists and will be overwritten: {root}")
 
+    def _strip_test_prefix(path: str) -> str:
+        """Remove leading test category prefix from Claude-generated paths."""
+        stripped = re.sub(r'^test/(unit|integration|e2e|e2e_tests)/', '', path)
+        stripped = re.sub(r'^test/', '', stripped)
+        return stripped
+
     def _write(rel: pathlib.Path, content: str) -> None:
         target = root / rel
         try:
@@ -150,29 +157,32 @@ def _save_artifacts(state: dict, output_dir: str) -> pathlib.Path:
     # tests/unit/<filename>
     for filename, content in (state.get("unit_tests") or {}).items():
         if content:
-            target = (root / "tests" / "unit" / filename).resolve()
+            clean_name = _strip_test_prefix(filename)
+            target = (root / "tests" / "unit" / clean_name).resolve()
             if not str(target).startswith(str(root.resolve()) + os.sep):
                 print(f"  SKIPPED (unsafe path): {filename}")
                 continue
-            _write(pathlib.Path("tests") / "unit" / filename, content)
+            _write(pathlib.Path("tests") / "unit" / clean_name, content)
 
     # tests/integration/<filename>
     for filename, content in (state.get("integration_tests") or {}).items():
         if content:
-            target = (root / "tests" / "integration" / filename).resolve()
+            clean_name = _strip_test_prefix(filename)
+            target = (root / "tests" / "integration" / clean_name).resolve()
             if not str(target).startswith(str(root.resolve()) + os.sep):
                 print(f"  SKIPPED (unsafe path): {filename}")
                 continue
-            _write(pathlib.Path("tests") / "integration" / filename, content)
+            _write(pathlib.Path("tests") / "integration" / clean_name, content)
 
     # tests/e2e/<filename>
     for filename, content in (state.get("e2e_tests") or {}).items():
         if content:
-            target = (root / "tests" / "e2e" / filename).resolve()
+            clean_name = _strip_test_prefix(filename)
+            target = (root / "tests" / "e2e" / clean_name).resolve()
             if not str(target).startswith(str(root.resolve()) + os.sep):
                 print(f"  SKIPPED (unsafe path): {filename}")
                 continue
-            _write(pathlib.Path("tests") / "e2e" / filename, content)
+            _write(pathlib.Path("tests") / "e2e" / clean_name, content)
 
     # docs/pr_description.md
     pr_description = state.get("pr_description")


### PR DESCRIPTION
## Problem

Test files were written to `tests/unit/test/unit/github_webhook/validator_test.go` instead of `tests/unit/github_webhook/validator_test.go`.

**Root cause:** Claude generates test dict keys with a leading `test/unit/` prefix (e.g. `test/unit/github_webhook/validator_test.go`). Both `_save_artifacts()` in `orchestrate.py` and `_write_go_test_files()` in `testing_agent.py` then prepend `tests/unit/` — doubling the path.

## Fix

Added `_strip_test_category_prefix()` helper that strips the leading `test/(unit|integration|e2e)/` segment before the path is joined to the destination directory.

Applied in three places:
- `scripts/orchestrate.py` — `_save_artifacts()` for all three test types
- `agents/testing_agent.py` — `_write_go_test_files()` for disk writes
- `agents/testing_agent.py` — `test_plan.md` path listing (so plan matches actual files)

## Result

`test/unit/github_webhook/validator_test.go` → `tests/unit/github_webhook/validator_test.go`