### PR TITLE
refactor(docs): restructure docs — dashboard-first, CLI/API reference pages, fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,13 @@ Development → Code Review ──PASS──→ Testing
 
 ## Repository Support
 
-- **Upstream (Shipwright)**: configured via `SHIPWRIGHT_REPO_PATH` — the open-source Shipwright Build repository, used for design context and component analysis.
-- **Downstream (OpenShift Builds)**: configured via `OPENSHIFT_BUILDS_REPO_PATH` — the Red Hat downstream fork, used for integration context and downstream-specific concerns.
+Configure repository paths so agents can analyze actual Go types, CRDs, and controllers from source. Use `repos.yaml` for multi-repo setups:
+
+```bash
+cp repos.yaml.example repos.yaml  # edit with your local clone paths
+```
+
+See [Configuration](docs/user-guide/01-getting-started/configuration.md#repository-paths) for details. Environment variables (`SHIPWRIGHT_REPO_PATH`, `OPENSHIFT_BUILDS_REPO_PATH`) are also supported for single-repo setups.
 
 ---
 
@@ -68,21 +73,15 @@ git clone <repo> && cd muilti-agents-ocp-builds
 uv venv && uv pip install -r requirements.txt
 cp .env.example .env  # fill in credentials
 
-# 2. Run from a Jira ticket
-uv run python scripts/orchestrate.py \
-  --jira-ticket BUILD-1707 \
-  --output-dir ./output/BUILD-1707
-
-# 3. Monitor in real time
+# 2. Run the dashboard
 uv run python scripts/run_dashboard.py  # http://localhost:8080
-
-# 4. Publish artifacts
-uv run python scripts/publish.py \
-  --output-dir ./output/BUILD-1707 \
-  --push-code --push-jira
 ```
 
-See [Setup and Quick Start](docs/user-guide/01-getting-started/quick-start.md) for full configuration — Jira, GitHub, Qodo, and Vertex AI.
+Open [http://localhost:8080](http://localhost:8080) and click **New Run**. Enter a Jira ticket ID (e.g. `BUILD-1707`) or a feature description, then click **Run Feature**. The pipeline runs all five phases and shows progress in real time.
+
+For CLI and automation usage, see the [CLI Reference](docs/user-guide/10-reference/cli.md).
+
+See [Quick Start](docs/user-guide/01-getting-started/quick-start.md) for full credential setup (Vertex AI, Jira, GitHub).
 
 ---
 
@@ -112,10 +111,12 @@ output/BUILD-1707/
 
 | Section | Content |
 |---------|---------|
-| [Setup & Quick Start](docs/user-guide/01-getting-started/quick-start.md) | All integrations: Jira, GitHub, Qodo, Vertex AI, repo paths |
+| [Quick Start](docs/user-guide/01-getting-started/quick-start.md) | Dashboard-first setup: install, configure credentials, run |
+| [Dashboard](docs/user-guide/04-dashboard/overview.md) | Web UI pages, real-time monitoring, session management |
 | [Architecture](docs/user-guide/02-concepts/architecture.md) | Pipeline design, state management, security layers |
 | [Agents](docs/user-guide/03-agents/design-agent.md) | Per-agent reference |
-| [Dashboard](docs/user-guide/04-dashboard/overview.md) | Real-time monitoring |
+| [CLI Reference](docs/user-guide/10-reference/cli.md) | All CLI commands for scripting and automation |
+| [API Reference](docs/user-guide/10-reference/api.md) | REST API endpoints, heartbeat protocol, database schema |
 | [Authentication](docs/user-guide/05-authentication/authentication.md) | Vertex AI setup |
 | [Publishing](docs/user-guide/09-integrations/publish.md) | Push to GitHub / Jira |
 
@@ -125,7 +126,7 @@ output/BUILD-1707/
 
 | Requirement | Detail |
 |-------------|--------|
-| Python | 3.11+ |
+| Python | 3.12+ |
 | Claude | Google Vertex AI (Application Default Credentials) |
 | Jira | API token for ticket fetching |
 | GitHub | PAT for PR enrichment and publishing |

--- a/docs/user-guide/01-getting-started/configuration.md
+++ b/docs/user-guide/01-getting-started/configuration.md
@@ -30,7 +30,7 @@ ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project
 CLOUD_ML_REGION=us-east5
 ```
 
-See [Vertex AI Setup](../05-authentication/vertex-ai.md) for authentication instructions.
+See [Vertex AI Setup](../05-authentication/authentication.md) for authentication instructions.
 
 ### Claude Model
 

--- a/docs/user-guide/01-getting-started/installation.md
+++ b/docs/user-guide/01-getting-started/installation.md
@@ -10,7 +10,7 @@ Set up the Multi-Agent OCP Builds system on your local machine.
 
 | Requirement | Version | Notes |
 |-------------|---------|-------|
-| Python | 3.11 or higher | Required for type hints and performance |
+| Python | 3.12 or higher | Required for type hints and performance |
 | Git | 2.0 or higher | For repository operations |
 | uv | Latest | Recommended Python package installer |
 | Google Cloud CLI | Latest | Required for Vertex AI authentication |
@@ -31,7 +31,7 @@ uv --version
 
 ```bash
 python --version
-# Expected: Python 3.11.x or higher
+# Expected: Python 3.12.x or higher
 ```
 
 ---
@@ -115,7 +115,7 @@ OK docs agent
 
 - [Quick Start](quick-start.md) - Run your first workflow
 - [Configuration](configuration.md) - Full environment variable reference
-- [Vertex AI Setup](../05-authentication/vertex-ai.md) - Detailed authentication guide
+- [Vertex AI Setup](../05-authentication/authentication.md) - Detailed authentication guide
 
 ---
 

--- a/docs/user-guide/01-getting-started/quick-start.md
+++ b/docs/user-guide/01-getting-started/quick-start.md
@@ -1,144 +1,57 @@
-# Setup and Quick Start
+# Quick Start
 
-Everything you need to go from zero to running the full agent pipeline.
+Everything you need to go from zero to running your first pipeline. The FlowPilot dashboard is the recommended interface — it provides a web UI for creating runs, monitoring progress, streaming logs, and downloading artifacts. A [CLI](../10-reference/cli.md) is also available for scripting and automation.
 
 ---
 
-## 1. Prerequisites
-
-**Required tools:**
-
-- Python 3.12+
-- [uv](https://docs.astral.sh/uv/getting-started/installation/) — Python package manager
-- [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) (`gcloud`) — for Vertex AI authentication
-- [gh CLI](https://cli.github.com/) — required only if using `publish.py --push-code`
-
-**Clone and install:**
+## 1. Install
 
 ```bash
 git clone https://github.com/your-org/muilti-agents-ocp-builds.git
 cd muilti-agents-ocp-builds
 uv venv && uv pip install -r requirements.txt
-```
-
-**Copy the example environment file:**
-
-```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in the sections that follow.
+Open `.env` in your editor and fill in the credentials from the sections below.
+
+**Prerequisites:** Python 3.12+, [uv](https://docs.astral.sh/uv/getting-started/installation/), [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) (`gcloud`).
 
 ---
 
-## 2. Configure Claude API (Google Vertex AI)
+## 2. Configure Claude API (Vertex AI)
 
-The system uses Google Vertex AI to access Claude. No API key is stored anywhere — authentication is handled entirely through Application Default Credentials (ADC) managed by the Google Cloud CLI.
-
-### Step 1: Install the Google Cloud CLI
-
-Follow the official guide: <https://cloud.google.com/sdk/docs/install>
-
-Verify the installation:
+The system uses Google Vertex AI to access Claude. Authentication is handled through Application Default Credentials (ADC) — no API key is stored anywhere.
 
 ```bash
-gcloud --version
-```
-
-### Step 2: Authenticate
-
-```bash
+# One-time setup
 gcloud auth application-default login
-```
-
-This opens a browser window for Google account sign-in. Credentials are cached at `~/.config/gcloud/application_default_credentials.json`.
-
-### Step 3: Set the billing project
-
-```bash
 gcloud auth application-default set-quota-project YOUR_GCP_PROJECT_ID
-```
-
-If you do not know your project ID:
-
-```bash
-gcloud projects list
-```
-
-### Step 4: Enable the Vertex AI API
-
-```bash
 gcloud services enable aiplatform.googleapis.com --project=YOUR_GCP_PROJECT_ID
 ```
 
-### Step 5: Grant IAM permissions
-
-Your account needs the `roles/aiplatform.user` role:
+Add to `.env`:
 
 ```bash
-gcloud projects add-iam-policy-binding YOUR_GCP_PROJECT_ID \
-  --member="user:your-email@example.com" \
-  --role="roles/aiplatform.user"
-```
-
-### Step 6: Set environment variables
-
-In your `.env` file:
-
-```bash
-# Required
 ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
-
-# Optional — defaults to us-east5
-CLOUD_ML_REGION=us-east5
+CLOUD_ML_REGION=us-east5  # Optional, defaults to us-east5
 ```
 
-Available regions: `us-east5` (default), `us-central1`, `europe-west1`, `asia-southeast1`.
-
-### Model selection
-
-```bash
-# Claude model to use (default: claude-sonnet-4-6)
-CLAUDE_MODEL=claude-sonnet-4-6
-
-# Max tokens per response (default: 8000)
-# Development and Testing agents override this with 16000 automatically
-CLAUDE_MAX_TOKENS=8000
-```
-
-### Verify authentication
+Verify:
 
 ```bash
 gcloud auth application-default print-access-token
 ```
 
-Or run the bundled auth example:
-
-```bash
-uv run python examples/auth_example.py
-```
+See [Authentication](../05-authentication/authentication.md) for full Vertex AI setup including IAM permissions and troubleshooting.
 
 ---
 
-## 3. Configure Jira
+## 3. Configure Jira (Recommended)
 
-Jira integration lets you pass a ticket ID directly to the pipeline instead of writing `--title` and `--description` by hand. The system fetches the title, description, acceptance criteria, priority, labels, and linked issues automatically.
+Jira integration lets you pass a ticket ID directly to the pipeline. The system fetches title, description, acceptance criteria, priority, labels, and linked issues automatically.
 
-**Required variables:**
-
-| Variable          | Description                              |
-| ----------------- | ---------------------------------------- |
-| `JIRA_BASE_URL`   | Your Atlassian Cloud base URL            |
-| `JIRA_USER_EMAIL` | The email address tied to your API token |
-| `JIRA_API_TOKEN`  | Your Atlassian API token                 |
-
-**Generate a Jira API token:**
-
-1. Go to <https://id.atlassian.com/manage-profile/security>
-2. Under "API tokens", click "Create API token"
-3. Give it a name and copy the generated value
-
-Add to your `.env` file:
+Add to `.env`:
 
 ```bash
 JIRA_BASE_URL=https://your-org.atlassian.net
@@ -146,342 +59,103 @@ JIRA_USER_EMAIL=your-email@company.com
 JIRA_API_TOKEN=your-api-token-here
 ```
 
-> **VPN required:** The Jira REST API endpoint is not reachable from outside the corporate network. If you are working off-VPN, use `--dry-run` mode instead.
+Generate a token at [https://id.atlassian.com/manage-profile/security](https://id.atlassian.com/manage-profile/security).
+
+> **VPN required:** The Jira REST API is not reachable outside the corporate network. Use dry-run mode when off-VPN.
+
+See [Jira & Rovo Integration](../09-integrations/jira-rovo.md) for full details.
 
 ---
 
-## 4. Configure GitHub
+## 4. Configure GitHub (Optional)
 
-GitHub integration enriches the docs agent with upstream PR context when Jira tickets have linked pull requests. It is also required by `publish.py --push-code` when pushing generated artifacts as a pull request.
+Enriches the docs agent with upstream PR context from Jira-linked pull requests. Also required by `publish.py` for pushing generated code as a PR.
 
-| Variable                    | Purpose                                                                                   |
-| --------------------------- | ----------------------------------------------------------------------------------------- |
-| `GITHUB_TOKEN`              | Fetches PR metadata from Jira-linked pull requests; required for `publish.py --push-code` |
-| `TARGET_GITHUB_REPO`        | Target repository for `publish.py --push-code`, in `org/repo` format                      |
-| `TARGET_GITHUB_BASE_BRANCH` | Base branch the generated PR targets (default: `main`)                                    |
-
-**Create a GitHub personal access token:**
-
-1. Go to GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
-2. Set "Contents" to read-only on the target repositories
-3. If using `publish.py --push-code`, also grant "Contents" write permission on the target repository
-
-Add to your `.env` file:
+Add to `.env`:
 
 ```bash
-# Enriches docs agent with upstream PR context
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
-GITHUB_REQUEST_TIMEOUT=10
-
-# Required by publish.py --push-code
 TARGET_GITHUB_REPO=openshift-builds/builds
 TARGET_GITHUB_BASE_BRANCH=main
 ```
 
-Without a `GITHUB_TOKEN`, the pipeline continues normally — PR enrichment is silently skipped.
+Without a `GITHUB_TOKEN`, the pipeline runs normally — PR enrichment is silently skipped.
 
 ---
 
-## 5. Configure Qodo Code Review (optional)
+## 5. Configure Repository Paths (Optional)
 
-The code review phase runs between Development and Testing and can automatically route failing code back to the Development agent for fixes. By default it uses Claude with no additional tools. Qodo CLI is an optional enhancement that adds static analysis on top of the Claude review.
-
-**Two modes:**
-
-| Mode | What it requires | When to use |
-|------|-----------------|-------------|
-| Claude-only (default) | Nothing — works out of the box | Most users |
-| Qodo CLI + Claude | `npm install -g @qodo/command` + auth | Enhanced static analysis |
-
-**Enable Qodo CLI (optional):**
+Repository paths let agents analyze actual Go types, CRDs, and controllers from source for more accurate analysis and code generation. Configure multiple repositories using `repos.yaml`:
 
 ```bash
-npm install -g @qodo/command
+cp repos.yaml.example repos.yaml
 ```
 
-Then set the path in `.env`:
+Edit `repos.yaml` to list your local clones:
 
-```bash
-QODO_CLI_PATH=/home/user/.npm-global/bin/qodo
+```yaml
+repos:
+  - path: /home/user/git/shipwright-io/build
+  - path: /home/user/git/shipwright-io/operator
+  - path: /home/user/git/redhat-openshift-builds/operator
 ```
 
-**Authenticate Qodo:**
+See `repos.yaml.example` for a full template with all Shipwright and OpenShift Builds repositories.
 
-For local development, run the interactive login once:
+**Alternative:** Set `SHIPWRIGHT_REPO_PATH` and `OPENSHIFT_BUILDS_REPO_PATH` in `.env` for single-repo setups. See [Configuration](configuration.md) for details.
 
-```bash
-qodo login
-```
-
-This stores the OAuth token at `~/.qodo/auth.key`. No further configuration is needed.
-
-For CI or headless environments, use an API key instead:
-
-```bash
-# Generate at: https://app.qodo.ai/settings/api-keys
-QODO_API_KEY=your-qodo-api-key
-```
-
-**Code review variables:**
-
-```bash
-# Set to false to skip code review entirely
-QODO_REVIEW_ENABLED=true
-
-# Maximum auto-fix iterations before continuing to Testing regardless
-MAX_REVIEW_ITERATIONS=3
-
-# Severity threshold that triggers the auto-fix loop
-# high   = block only on [BLOCKING] findings (default)
-# medium = block on [BLOCKING] and [WARNING] findings
-# low    = block on any finding
-QODO_BLOCKING_THRESHOLD=high
-```
-
-If Qodo CLI is unavailable, exits with an error, or times out, the agent automatically falls back to Claude-only review. The pipeline is never blocked by a Qodo CLI failure.
+Without repo paths, agents fall back to component metadata only. Analysis is still valid, but less precise.
 
 ---
 
-## 6. Configure Repository Paths
+## 6. Run
 
-Repository paths are optional but strongly recommended. When set, the design agent reads actual Go types, CRDs, and controllers from source to produce more accurate component impact analysis.
-
-**Upstream — Shipwright Build (open-source):**
-
-```bash
-# The open-source Shipwright Build repository
-# Design agent uses this to analyze Go types, CRDs, and controllers
-SHIPWRIGHT_REPO_PATH=/home/user/git/shipwright-build
-```
-
-Clone the upstream repo if you do not have it:
-
-```bash
-git clone https://github.com/shipwright-io/build.git /home/user/git/shipwright-build
-```
-
-**Downstream — OpenShift Builds (Red Hat fork):**
-
-```bash
-# The Red Hat downstream fork
-# Provides downstream-specific patches and configurations
-OPENSHIFT_BUILDS_REPO_PATH=/home/user/git/openshift-builds
-```
-
-Without these paths, the design agent falls back to component metadata only. Analysis is still valid, but less precise for deeply nested type hierarchies.
-
----
-
-## 7. Debug and Logging
-
-**CLI flag — single run only:**
-
-The `--debug` flag enables `DEBUG` log level for a single pipeline run without changing your `.env`:
-
-```bash
-uv run python scripts/orchestrate.py \
-  --jira-ticket BUILD-123 \
-  --output-dir ./output/BUILD-123 \
-  --debug
-```
-
-**Persistent logging via `.env`:**
-
-```bash
-# Verbosity: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: INFO)
-LOG_LEVEL=DEBUG
-
-# Format: text or json (default: text)
-LOG_FORMAT=text
-
-# Write logs to a file in addition to stdout (optional)
-LOG_FILE_PATH=/tmp/muilti-agents-ocp-builds.log
-```
-
----
-
-## 8. Run the Pipeline
-
-### From a Jira ticket (recommended)
-
-```bash
-uv run python scripts/orchestrate.py \
-  --jira-ticket BUILD-1707 \
-  --output-dir ./output/BUILD-1707
-```
-
-The orchestrator fetches the ticket data automatically and runs the full five-phase pipeline: Design → Development → Code Review → Testing → Documentation.
-
-### From a title and description
-
-```bash
-uv run python scripts/orchestrate.py \
-  --title "Add timeout support to BuildRun" \
-  --description "Users need configurable timeouts to prevent hanging builds" \
-  --output-dir ./output
-```
-
-### With debug logging
-
-```bash
-uv run python scripts/orchestrate.py \
-  --jira-ticket BUILD-1707 \
-  --output-dir ./output/BUILD-1707 \
-  --debug
-```
-
-### What the output directory contains
-
-When `--output-dir` is specified, the directory is created if it does not exist. Artifacts saved:
-
-| Path | Contents |
-|------|----------|
-| `state.json` | Full pipeline state |
-| `design/` | Design analysis, component impact, risks, acceptance criteria |
-| `code/` | Generated Go source files |
-| `tests/` | Generated Ginkgo v2 test files |
-| `docs/` | PR summary, release notes, user documentation |
-
-The `--output-dir` path is required by `scripts/publish.py` when pushing artifacts to GitHub or Jira.
-
-### What happens during a run
-
-The terminal prints a header for each phase with a per-phase timer:
-
-```text
-Phase 1/5 · Design
-Phase 2/5 · Development
-Phase 3/5 · Code Review
-Phase 4/5 · Testing
-Phase 5/5 · Documentation
-```
-
-When all phases finish, a summary is printed:
-
-```text
-Run complete
-  Duration:   3m 42s
-  Artifacts:  ./output/BUILD-1707
-  Dashboard:  http://localhost:8080
-```
-
-If an agent raises an unhandled exception, the workflow sets `current_phase = "error"` and stops early. The final state contains the error message.
-
-### Dry run (no credentials needed)
-
-Use `--dry-run` to run without credentials or VPN. Pre-configured mock responses are used and no API calls are made:
-
-```bash
-uv run python scripts/orchestrate.py --jira-ticket SHIP-123 --dry-run
-```
-
----
-
-## 9. Monitor with the Dashboard
-
-Start the dashboard before running the orchestrator to watch each agent's progress in real time.
-
-**Terminal 1 — start the dashboard:**
+Start the dashboard and open the web UI:
 
 ```bash
 uv run python scripts/run_dashboard.py
 ```
 
-Open http://localhost:8080 in your browser.
+Open [http://localhost:8080](http://localhost:8080) in your browser. Click **New Run** and fill in:
 
-**Terminal 2 — run the pipeline:**
+1. **Feature description** — describe the feature or bug to work on
+2. **Jira Ticket** (recommended) — enter a ticket ID like `BUILD-123` to auto-fetch context
+3. Click **Run Feature**
 
-```bash
-uv run python scripts/orchestrate.py \
-  --jira-ticket BUILD-1707 \
-  --output-dir ./output/BUILD-1707
-```
+The pipeline runs all five phases automatically: Design → Development → Code Review → Testing → Documentation. Progress is visible in real time on the Dashboard page.
 
-The dashboard shows each agent's current phase, context window usage, impacted components, and — when a Jira ticket is used — a badge linking directly to the ticket.
+### Try It Without Credentials
 
----
+Use dry-run mode to test the system without API credentials or VPN:
 
-## 10. Publish Artifacts (optional)
+1. Open `http://localhost:8080`
+2. Click **New Run**
+3. Toggle **Dry Run** to `On` in Advanced Options
+4. Enter any description and click **Run Feature**
 
-After a pipeline run, `scripts/publish.py` can push the generated artifacts to GitHub or update the Jira ticket.
+### Alternative: CLI
 
-**Push generated code as a pull request:**
-
-Requires `GITHUB_TOKEN`, `TARGET_GITHUB_REPO`, and `TARGET_GITHUB_BASE_BRANCH` to be set (see [section 4](#4-configure-github)).
-
-```bash
-uv run python scripts/publish.py \
-  --output-dir ./output/BUILD-1707 \
-  --push-code
-```
-
-**Update the Jira ticket:**
-
-Requires Jira credentials to be set (see [section 3](#3-configure-jira)).
+For scripting and automation, see the [CLI Reference](../10-reference/cli.md):
 
 ```bash
-uv run python scripts/publish.py \
-  --output-dir ./output/BUILD-1707 \
-  --push-jira
-```
-
-Both flags can be combined:
-
-```bash
-uv run python scripts/publish.py \
-  --output-dir ./output/BUILD-1707 \
-  --push-code \
-  --push-jira
-```
-
----
-
-## Complete .env Reference
-
-A minimal working `.env` for live runs:
-
-```bash
-# Required — Vertex AI authentication
-ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
-CLOUD_ML_REGION=us-east5
-
-# Jira integration
-JIRA_BASE_URL=https://your-org.atlassian.net
-JIRA_USER_EMAIL=your-email@company.com
-JIRA_API_TOKEN=your-api-token-here
-
-# GitHub integration (optional but recommended)
-GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
-TARGET_GITHUB_REPO=openshift-builds/builds
-TARGET_GITHUB_BASE_BRANCH=main
-
-# Repository paths (optional but recommended)
-SHIPWRIGHT_REPO_PATH=/home/user/git/shipwright-build
-OPENSHIFT_BUILDS_REPO_PATH=/home/user/git/openshift-builds
-
-# Model settings
-CLAUDE_MODEL=claude-sonnet-4-6
-CLAUDE_MAX_TOKENS=8000
-
-# Logging
-LOG_LEVEL=INFO
-LOG_FORMAT=text
-
-# Code review
-QODO_REVIEW_ENABLED=true
-MAX_REVIEW_ITERATIONS=3
-QODO_BLOCKING_THRESHOLD=high
+uv run python scripts/orchestrate.py --jira-ticket BUILD-1707 --output-dir ./output
 ```
 
 ---
 
 ## Next Steps
 
-- [Architecture](../02-concepts/architecture.md) — How the LangGraph pipeline and agent state work
-- [Agents Overview](../02-concepts/agents-overview.md) — What each agent does and what it produces
-- [Dashboard Overview](../04-dashboard/overview.md) — Dashboard features and session tracking
-- [Configuration Reference](configuration.md) — Full list of all environment variables
+| I want to... | Go to |
+| --- | --- |
+| Understand the dashboard pages | [Dashboard Overview](../04-dashboard/overview.md) |
+| Learn what each agent does | [Agents Overview](../02-concepts/agents-overview.md) |
+| See all environment variables | [Configuration](configuration.md) |
+| Run from the command line | [CLI Reference](../10-reference/cli.md) |
+| Use the REST API directly | [API Reference](../10-reference/api.md) |
+| Test without API calls | [Dry Run Mode](../06-advanced/dry-run-mode.md) |
+| Set up Vertex AI authentication | [Authentication](../05-authentication/authentication.md) |
+| Publish artifacts to GitHub/Jira | [Publishing](../09-integrations/publish.md) |
 
 ---
 
-[Next: Configuration →](configuration.md)
+[← Installation](installation.md) | [Configuration →](configuration.md)

--- a/docs/user-guide/02-concepts/agents-overview.md
+++ b/docs/user-guide/02-concepts/agents-overview.md
@@ -191,9 +191,9 @@ For full parameter documentation, see the [Docs Agent](../03-agents/docs-agent.m
 
 ## Publish
 
-After all four phases complete, `publish.py` pushes the generated code to a GitHub branch and posts results back to Jira.
+After all five phases complete, `publish.py` pushes the generated code to a GitHub branch and posts results back to Jira.
 
-See the [Publish](../04-publishing/publish.md) page for configuration and usage.
+See the [Publish](../09-integrations/publish.md) page for configuration and usage.
 
 ---
 

--- a/docs/user-guide/04-dashboard/session-management.md
+++ b/docs/user-guide/04-dashboard/session-management.md
@@ -48,6 +48,10 @@ Archived runs display a red **Delete** button. Clicking it opens a browser confi
 
 Confirming the dialog permanently removes the session, all associated heartbeat records, and the pipeline log file from disk.
 
+### Clean Stale Sessions
+
+A **Clean stale sessions** button is available above the runs table. Clicking it removes sessions that appear stuck — sessions in an active phase with no recent heartbeat. This is useful when agent processes have crashed or lost connectivity, leaving sessions in a permanently "running" state.
+
 ### Status Card Counts
 
 The four summary cards at the top of the dashboard (Running, Waiting, Failed, Completed) are computed from whichever sessions are currently loaded. By default, archived sessions are excluded from the API response, so they do not contribute to any card count. Archiving a failed run, for example, removes it from view and decreases the Failed count by one. Toggling **Show archived** re-fetches all sessions including archived ones, so their original status is reflected in the counts again.
@@ -115,6 +119,27 @@ Response:
 }
 ```
 
+### Delete Stuck Sessions
+
+Remove sessions that have been inactive (no new heartbeat) for a specified duration while still in a non-terminal phase. Useful for cleaning up sessions where the agent process has crashed or lost connectivity. Defaults to 6 hours.
+
+```bash
+# Default: delete sessions stuck for 6+ hours
+curl -X DELETE http://localhost:8080/api/sessions/stuck
+
+# Custom: delete sessions stuck for 2+ hours
+curl -X DELETE "http://localhost:8080/api/sessions/stuck?max_stale_hours=2"
+```
+
+Response:
+
+```json
+{
+  "sessions_deleted": 2,
+  "heartbeats_deleted": 8
+}
+```
+
 ---
 
 ## Python Client Examples
@@ -135,6 +160,14 @@ print(f"Deleted {result['heartbeats_deleted']} heartbeats")
 response = requests.delete("http://localhost:8080/api/sessions/completed")
 result = response.json()
 print(f"Cleared {result['sessions_cleared']} completed sessions")
+
+# Delete stuck sessions (no heartbeat for 2+ hours)
+response = requests.delete(
+    "http://localhost:8080/api/sessions/stuck",
+    params={"max_stale_hours": 2}
+)
+result = response.json()
+print(f"Deleted {result['sessions_deleted']} stuck sessions")
 ```
 
 ---
@@ -198,7 +231,16 @@ Deletes sessions that meet ANY of these conditions:
 2. No age restriction applies
 3. Cascade: also deletes all associated heartbeat records
 
-**Active sessions are never deleted by either endpoint.**
+### `DELETE /api/sessions/stuck` (stale sessions)
+
+Deletes sessions that meet ALL of these conditions:
+1. Phase is NOT `done` or `error` (i.e., the session appears to still be running)
+2. Last heartbeat was received more than `max_stale_hours` ago (default: 6 hours)
+3. Cascade: also deletes all associated heartbeat records
+
+**Completed and errored sessions are never affected by this endpoint.**
+
+**Active sessions are never deleted by either the cleanup or completed endpoints.**
 
 ---
 

--- a/docs/user-guide/06-advanced/dry-run-mode.md
+++ b/docs/user-guide/06-advanced/dry-run-mode.md
@@ -215,4 +215,4 @@ INFO  | multi_agent_testing | Artifact saved: /tmp/claude/agent-tests/design_out
 
 ---
 
-[← Previous: API Key](../05-authentication/api-key.md) | [Next: Logging →](logging.md) | [Output Validation →](output-validation.md)
+[← Previous: Authentication](../05-authentication/authentication.md) | [Next: Logging →](logging.md) | [Output Validation →](output-validation.md)

--- a/docs/user-guide/09-integrations/jira-rovo.md
+++ b/docs/user-guide/09-integrations/jira-rovo.md
@@ -10,7 +10,7 @@ Before using this integration, confirm you have:
 
 - The system installed and working (see [Installation](../01-getting-started/installation.md))
 - VPN access to reach your internal Jira instance
-- A Jira API token (see [Jira API Token](../05-authentication/api-key.md#jira-api-token))
+- A Jira API token (see [Jira API Token](../05-authentication/authentication.md#jira-api-token))
 
 The three required environment variables are:
 

--- a/docs/user-guide/10-reference/api.md
+++ b/docs/user-guide/10-reference/api.md
@@ -1,0 +1,251 @@
+# API Reference
+
+The FlowPilot dashboard exposes a REST API served by a FastAPI backend at `http://localhost:8080`. All endpoints accept and return JSON unless otherwise noted. Interactive API documentation is available at `http://localhost:8080/docs` when the dashboard is running.
+
+---
+
+## Core Endpoints
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| GET | `/api/health` | Health check -- returns `{"status": "healthy", "db_path": "..."}` |
+| POST | `/api/heartbeat` | Receive an agent heartbeat (see [Heartbeat Protocol](#heartbeat-protocol)) |
+| POST | `/api/runs` | Launch a new pipeline run from the web UI |
+
+---
+
+## Session Endpoints
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| GET | `/api/sessions` | List all sessions. Add `?include_archived=true` to include archived runs. |
+| GET | `/api/sessions/{id}` | Get a specific session with all heartbeats |
+| PATCH | `/api/sessions/{id}/archive` | Archive a session (hides from default list, preserves data) |
+| DELETE | `/api/sessions/{id}` | Permanently delete a session, all heartbeats, and the log file |
+| DELETE | `/api/sessions/cleanup` | Delete completed sessions older than N hours (`?max_age_hours=24`, default 24) |
+| DELETE | `/api/sessions/completed` | Delete all completed or errored sessions regardless of age |
+| DELETE | `/api/sessions/stuck` | Delete stale sessions with no heartbeat in N hours (`?max_stale_hours=6`, default 6) |
+
+---
+
+## Run Control Endpoints
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| POST | `/api/sessions/{id}/approve` | Signal approval or rejection (`?action=approve` or `?action=reject`) |
+| POST | `/api/sessions/{id}/pause` | Signal a running pipeline to pause after the current phase |
+
+---
+
+## Log Streaming
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| GET | `/api/sessions/{id}/logs` | Stream pipeline logs via Server-Sent Events (SSE) |
+
+The Logs tab in the Run Details page connects to this endpoint. Logs are read from `/tmp/claude/logs/{session-id}.log` and streamed in real time.
+
+---
+
+## Artifact Downloads
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| GET | `/api/sessions/{id}/download/all` | Download all artifacts as a single zip |
+| GET | `/api/sessions/{id}/download/design` | Download design analysis as Markdown |
+| GET | `/api/sessions/{id}/download/code` | Download generated code files as a zip |
+| GET | `/api/sessions/{id}/download/tests` | Download test files as a zip (unit, integration, e2e) |
+| GET | `/api/sessions/{id}/download/docs` | Download documentation files as a zip |
+
+---
+
+## Heartbeat Protocol
+
+Each agent calls `emit_heartbeat(agent_name, state)` at the start and end of its phase. The `HeartbeatEmitter` in `dashboard/heartbeat.py` sends an HTTP POST to `/api/heartbeat`.
+
+```python
+# Called inside each agent node -- example from graph.py
+emit_heartbeat("design", {**state, "phase": "design_complete"})
+```
+
+If the dashboard is unreachable, heartbeats fail silently. The workflow is never blocked by dashboard availability.
+
+### Heartbeat Payload
+
+```json
+{
+  "session_id": "abc-123-def-456",
+  "agent": "design",
+  "phase": "design_complete",
+  "timestamp": "2026-03-15T10:00:00",
+  "raw_state": {
+    "issue_title": "Add timeout support",
+    "issue_number": 42,
+    "issue_type": "feature",
+    "design_analysis": "...",
+    "impacted_components": ["BuildRun", "Build"]
+  }
+}
+```
+
+Valid `phase` values: `planning`, `design`, `design_complete`, `develop`, `develop_complete`, `code_review`, `code_review_complete`, `testing`, `testing_complete`, `docs`, `docs_complete`, `done`, `error`.
+
+The `agent` field identifies which agent emitted the heartbeat: `design`, `development`, `code_review`, `testing`, `docs`.
+
+---
+
+## Enricher Pipeline
+
+Raw heartbeat data passes through eight enrichers before storage. Each enricher adds computed fields to the heartbeat record.
+
+| Enricher | Purpose |
+| --- | --- |
+| **ModelInfoEnricher** | Reads the Claude model name from the environment |
+| **TokenCountEnricher** | Estimates context window usage percentage based on state size |
+| **PhaseStatusEnricher** | Maps `current_phase` to a human-readable status label |
+| **ComponentsEnricher** | Extracts impacted Shipwright components from state |
+| **RisksEnricher** | Extracts risks and derives an overall risk level |
+| **IssueInfoEnricher** | Extracts issue title, type, and description |
+| **JiraInfoEnricher** | Extracts Jira ticket ID, URL, priority, and labels |
+| **TimestampEnricher** | Adds formatted and relative timestamps |
+
+Enrichers are defined in `dashboard/enrichers.py` and run in sequence on every incoming heartbeat.
+
+---
+
+## Database Schema
+
+The dashboard stores data in two SQLite tables at `DASHBOARD_DB_PATH` (default: `/tmp/claude/dashboard.db`).
+
+```sql
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    issue_title TEXT,
+    issue_type TEXT,
+    status TEXT DEFAULT 'active'
+);
+
+CREATE TABLE heartbeats (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    phase TEXT,
+    timestamp TIMESTAMP NOT NULL,
+    model TEXT,
+    context_tokens INTEGER,
+    context_percent REAL,
+    status TEXT,
+    raw_state TEXT,
+    enriched_data TEXT,
+    FOREIGN KEY (session_id) REFERENCES sessions(id)
+);
+
+CREATE INDEX idx_session_timestamp
+ON heartbeats(session_id, timestamp DESC);
+```
+
+---
+
+## Automatic Cleanup
+
+A background task runs every 6 hours to clean up old sessions:
+
+| Target | Condition |
+| --- | --- |
+| Completed sessions | Phase is `done` or `error` and last updated more than 24 hours ago |
+| Stuck sessions | Non-terminal phase with no heartbeat for 4+ hours |
+
+The manual `DELETE /api/sessions/stuck` endpoint defaults to `max_stale_hours=6` but accepts a custom value. The background task uses a fixed 4-hour threshold.
+
+Cleanup events are logged:
+
+```text
+[INFO] [dashboard.backend] Started automatic cleanup task (runs every 6 hours)
+[INFO] [dashboard.backend] Automatic cleanup: {'sessions_deleted': 5, 'heartbeats_deleted': 23}
+```
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DASHBOARD_URL` | `http://localhost:8080` | URL where agents send heartbeats |
+| `DASHBOARD_ENABLED` | `true` | Set to `false` to disable heartbeat emissions |
+| `DASHBOARD_DB_PATH` | `/tmp/claude/dashboard.db` | SQLite database path |
+
+---
+
+## Example: curl
+
+```bash
+# Health check
+curl http://localhost:8080/api/health
+
+# List all sessions
+curl http://localhost:8080/api/sessions
+
+# List including archived
+curl "http://localhost:8080/api/sessions?include_archived=true"
+
+# Get a specific session
+curl http://localhost:8080/api/sessions/abc-123-def-456
+
+# Delete completed sessions older than 12 hours
+curl -X DELETE "http://localhost:8080/api/sessions/cleanup?max_age_hours=12"
+
+# Delete all completed sessions
+curl -X DELETE http://localhost:8080/api/sessions/completed
+
+# Delete stuck sessions (no heartbeat for 2+ hours)
+curl -X DELETE "http://localhost:8080/api/sessions/stuck?max_stale_hours=2"
+
+# Archive a session
+curl -X PATCH http://localhost:8080/api/sessions/abc-123-def-456/archive
+
+# Permanently delete a session
+curl -X DELETE http://localhost:8080/api/sessions/abc-123-def-456
+
+# Approve a waiting session
+curl -X POST "http://localhost:8080/api/sessions/abc-123-def-456/approve?action=approve"
+
+# Send a test heartbeat
+curl -X POST http://localhost:8080/api/heartbeat \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "test-123", "agent": "design", "phase": "done", "timestamp": "2026-03-15T10:00:00", "raw_state": {"issue_title": "Test"}}'
+```
+
+---
+
+## Example: Python
+
+```python
+import requests
+
+BASE = "http://localhost:8080"
+
+# List sessions
+sessions = requests.get(f"{BASE}/api/sessions").json()
+for s in sessions:
+    print(f"{s['id']}: {s.get('issue_title', 'untitled')} ({s['status']})")
+
+# Delete sessions older than 48 hours
+result = requests.delete(
+    f"{BASE}/api/sessions/cleanup",
+    params={"max_age_hours": 48}
+).json()
+print(f"Deleted {result['sessions_deleted']} sessions")
+
+# Delete stuck sessions
+result = requests.delete(
+    f"{BASE}/api/sessions/stuck",
+    params={"max_stale_hours": 2}
+).json()
+print(f"Deleted {result['sessions_deleted']} stuck sessions")
+```
+
+---
+
+[← CLI Reference](cli.md) | [Back to Index](../README.md)

--- a/docs/user-guide/10-reference/cli.md
+++ b/docs/user-guide/10-reference/cli.md
@@ -1,0 +1,266 @@
+# CLI Reference
+
+The CLI is available for scripting, automation, and CI/CD pipelines. For interactive use, the [FlowPilot dashboard](../04-dashboard/overview.md) provides a richer experience with real-time progress, log streaming, and artifact downloads. CLI runs emit heartbeats to the dashboard, so you can still monitor progress in the web UI.
+
+---
+
+## `scripts/orchestrate.py` -- Run the Pipeline
+
+The main entry point. Runs the full five-phase pipeline: Design --> Development --> Code Review --> Testing --> Documentation.
+
+### From a Jira Ticket (Recommended)
+
+```bash
+uv run python scripts/orchestrate.py \
+  --jira-ticket BUILD-1707 \
+  --output-dir ./output/BUILD-1707
+```
+
+### From a Title and Description
+
+```bash
+uv run python scripts/orchestrate.py \
+  --title "Add timeout support to BuildRun" \
+  --description "Users need configurable timeouts to prevent hanging builds" \
+  --output-dir ./output
+```
+
+### With GitHub Issue Context
+
+```bash
+uv run python scripts/orchestrate.py \
+  --title "Add timeout support" \
+  --description "Description" \
+  --github-issue SHIP-123 \
+  --output-dir ./output
+```
+
+GitHub issues can be specified as `SHIP-NNN`, `owner/repo#N`, or a full URL.
+
+### Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--jira-ticket KEY` | Jira ticket ID (e.g. `BUILD-1707`). Fetches title, description, and metadata automatically. | -- |
+| `--title TEXT` | Issue title (required if no `--jira-ticket`) | -- |
+| `--description TEXT` | Issue description | -- |
+| `--github-issue REF` | GitHub issue reference (`SHIP-123`, `owner/repo#N`, or URL) | -- |
+| `--issue-type TYPE` | Issue type: `feature`, `bug`, or `refactor` | `feature` |
+| `--output-dir PATH` | Directory for generated artifacts | -- |
+| `--dry-run` | Use mock responses, no API calls or credentials needed | `false` |
+| `--debug` | Enable `DEBUG` log level for this run | `false` |
+| `--manual-approval` | Pause after each phase for user approval | `false` |
+
+### Output Directory Structure
+
+When `--output-dir` is specified, artifacts are saved as:
+
+```text
+output/
+├── state.json          # Full pipeline state
+├── design/             # Design analysis, component impact, risks
+├── code/               # Generated Go source files
+├── tests/              # Generated Ginkgo v2 test files
+└── docs/               # PR summary, release notes
+```
+
+### What Happens During a Run
+
+The terminal prints a header for each phase with a per-phase timer:
+
+```text
+Phase 1/5 · Design
+Phase 2/5 · Development
+Phase 3/5 · Code Review
+Phase 4/5 · Testing
+Phase 5/5 · Documentation
+```
+
+When all phases finish:
+
+```text
+Run complete
+  Duration:   3m 42s
+  Artifacts:  ./output/BUILD-1707
+  Dashboard:  http://localhost:8080
+```
+
+If an agent raises an unhandled exception, the workflow sets `current_phase = "error"` and stops early.
+
+---
+
+## `scripts/run_dashboard.py` -- Start the Dashboard
+
+Starts the FastAPI backend and serves the React frontend.
+
+```bash
+uv run python scripts/run_dashboard.py
+```
+
+| Endpoint | URL |
+| --- | --- |
+| Web UI | `http://localhost:8080` |
+| API documentation | `http://localhost:8080/docs` |
+| Health check | `http://localhost:8080/api/health` |
+
+---
+
+## `scripts/test_agents.py` -- Test Agents
+
+Test individual agents or the full pipeline without running a production workflow.
+
+### Full E2E Workflow
+
+```bash
+uv run python scripts/test_agents.py --e2e --dry-run
+```
+
+### Single Agent
+
+```bash
+uv run python scripts/test_agents.py --agent design --dry-run --debug
+```
+
+### Custom Issue Data
+
+```bash
+uv run python scripts/test_agents.py --e2e --dry-run \
+  --title "Add SSH key support" \
+  --description "Users need to build from private Git repos"
+```
+
+### Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--agent {design\|testing\|docs}` | Test a specific agent | -- |
+| `--e2e` | Test complete E2E workflow | -- |
+| `--dashboard` | Test dashboard functionality | -- |
+| `--title TEXT` | Override issue title | Mock title |
+| `--description TEXT` | Override issue description | Mock description |
+| `--dry-run` | Use mock responses | `false` |
+| `--debug` | Enable verbose logging | `false` |
+| `--output-dir PATH` | Artifact output directory | `/tmp/claude/agent-tests` |
+
+### Output Artifacts
+
+| File | Description |
+| --- | --- |
+| `test_YYYYMMDD_HHMMSS.log` | Complete test log with timestamps |
+| `design_output.json` | Design agent structured output |
+| `testing_output.json` | Testing agent structured output |
+| `docs_output.json` | Docs agent structured output |
+| `review_output.json` | Code Review agent structured output |
+| `e2e_result.json` | Complete E2E workflow results |
+
+---
+
+## `scripts/publish.py` -- Publish Artifacts
+
+Push generated artifacts to GitHub or update the Jira ticket after a pipeline run. Requires `--output-dir` to point to a completed run's output directory.
+
+### Push Code as a Pull Request
+
+Requires `GITHUB_TOKEN`, `TARGET_GITHUB_REPO`, and `TARGET_GITHUB_BASE_BRANCH` in `.env`.
+
+```bash
+uv run python scripts/publish.py \
+  --output-dir ./output/BUILD-1707 \
+  --push-code
+```
+
+### Update the Jira Ticket
+
+Requires `JIRA_BASE_URL`, `JIRA_USER_EMAIL`, and `JIRA_API_TOKEN` in `.env`.
+
+```bash
+uv run python scripts/publish.py \
+  --output-dir ./output/BUILD-1707 \
+  --push-jira
+```
+
+### Both
+
+```bash
+uv run python scripts/publish.py \
+  --output-dir ./output/BUILD-1707 \
+  --push-code \
+  --push-jira
+```
+
+---
+
+## `examples/test_agents_demo.sh` -- Interactive Demo
+
+An interactive, menu-driven Bash script for testing agents, the full pipeline, and dashboard functionality.
+
+```bash
+chmod +x examples/test_agents_demo.sh
+./examples/test_agents_demo.sh
+```
+
+| Mode | Description |
+| --- | --- |
+| Dry-run | Mock responses, no API calls |
+| Live | Real API calls, requires Vertex AI credentials |
+
+| Test | Description |
+| --- | --- |
+| Individual agent | Test Design, Testing, or Docs agent in isolation |
+| E2E workflow | All five agents in sequence |
+| Dashboard | Test dashboard heartbeat and API |
+| All | Run every test in sequence |
+
+---
+
+## `examples/auth_example.py` -- Verify Authentication
+
+Validates Vertex AI authentication configuration without making API calls.
+
+```bash
+uv run python examples/auth_example.py
+```
+
+---
+
+## `examples/logger_demo.py` -- Logging Patterns
+
+Demonstrates all logging patterns: agent logging, session logging, log level control, and custom log paths.
+
+```bash
+uv run python examples/logger_demo.py
+```
+
+---
+
+## `examples/test_cleanup_api.py` -- Dashboard API Test
+
+Exercises every REST endpoint exposed by the dashboard backend. Requires the dashboard to be running.
+
+```bash
+# Terminal 1: start the dashboard
+uv run python scripts/run_dashboard.py
+
+# Terminal 2: run the API tests
+PYTHONPATH=. python examples/test_cleanup_api.py
+```
+
+---
+
+## Environment Variables That Affect CLI Behavior
+
+| Variable | Effect on CLI |
+| --- | --- |
+| `ANTHROPIC_VERTEX_PROJECT_ID` | Required for live runs. Not needed with `--dry-run`. |
+| `JIRA_BASE_URL` / `JIRA_USER_EMAIL` / `JIRA_API_TOKEN` | Required for `--jira-ticket`. Not needed with `--dry-run`. |
+| `CLAUDE_MODEL` | Model override (default: `claude-sonnet-4-6`) |
+| `LOG_LEVEL` | Persistent log level. `--debug` overrides this to `DEBUG` for one run. |
+| `MANUAL_APPROVAL` | Set to `true` to pause between phases. `--manual-approval` flag does the same per-run. |
+| `QODO_REVIEW_ENABLED` | Set to `false` to skip code review entirely. |
+| `DRY_RUN` | Set to `true` as an alternative to the `--dry-run` flag. |
+
+See [Configuration](../01-getting-started/configuration.md) for the full environment variable reference.
+
+---
+
+[← Back to Index](../README.md) | [API Reference →](api.md)

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -23,7 +23,7 @@ Each phase is handled by a dedicated AI agent. Artifacts are saved to `--output-
 | Page | Description |
 |------|-------------|
 | [Installation](01-getting-started/installation.md) | System requirements and install steps |
-| [Quick Start](01-getting-started/quick-start.md) | Complete setup guide covering all integrations (Jira, GitHub, Qodo, Vertex AI, repo paths) |
+| [Quick Start](01-getting-started/quick-start.md) | Dashboard-first setup: install, configure credentials, and run your first pipeline |
 | [Configuration](01-getting-started/configuration.md) | Environment variables and `.env` setup |
 
 ### Section 2 - Core Concepts & SDLC Pipeline
@@ -65,6 +65,7 @@ Each phase is handled by a dedicated AI agent. Artifacts are saved to `--output-
 | [Logging](06-advanced/logging.md) | Log files, levels, and session logs |
 | [Output Validation](06-advanced/output-validation.md) | Per-phase validation and manual approval |
 | [Troubleshooting](06-advanced/troubleshooting.md) | Common issues and fixes |
+| [Code Flow](06-advanced/code-flow.md) | Function call mapping across the pipeline |
 
 ### Section 7 - Security
 
@@ -75,24 +76,31 @@ Each phase is handled by a dedicated AI agent. Artifacts are saved to `--output-
 | [Log & Output Sanitizer](07-security/output-sanitizer.md)                   | Layer 3: egress protection — scrubs sensitive data from logs and outputs     |
 | [claude-hooks PostToolUse Integration](07-security/claude-hooks.md)         | Layer 4: host-level defense via Claude Code hooks                            |
 
-### Section 7 - Examples
+### Section 8 - Examples
 
 | Page | Description |
 | ---- | ----------- |
 | [Examples](07-examples/README.md) | Runnable scripts for testing agents, auth, logging, and the dashboard API |
 
-### Section 8 - Testing
+### Section 9 - Testing
 
 | Page                          | Description                                                                         |
 |-------------------------------|-------------------------------------------------------------------------------------|
 | [Testing](08-testing/README.md) | Test suite overview, dual-mode execution, fixtures, markers, and writing new tests |
 
-### Section 9 - Integrations
+### Section 10 - Integrations
 
 | Page                                                               | Description                                                                       |
 |--------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | [Jira & Rovo](09-integrations/jira-rovo.md)                        | Feed Jira tickets directly to the agent pipeline; Rovo MCP setup                  |
 | [Publishing Artifacts (`publish.py`)](09-integrations/publish.md)  | Push generated code, docs, and summaries to GitHub or Jira                        |
+
+### Section 11 - Reference
+
+| Page | Description |
+|------|-------------|
+| [CLI Reference](10-reference/cli.md) | All CLI commands, options, and usage examples |
+| [API Reference](10-reference/api.md) | REST API endpoints, heartbeat protocol, database schema |
 
 ---
 
@@ -114,6 +122,8 @@ Each phase is handled by a dedicated AI agent. Artifacts are saved to `--output-
 | Use a Jira ticket as workflow input | [Jira & Rovo Integration](09-integrations/jira-rovo.md) |
 | Publish code/docs to GitHub or Jira | [Publishing Artifacts](09-integrations/publish.md) |
 | Review generated code automatically | [Code Review Agent](03-agents/code-review-agent.md) |
+| Use the CLI for scripting | [CLI Reference](10-reference/cli.md) |
+| Use the REST API directly | [API Reference](10-reference/api.md) |
 
 ---
 
@@ -122,7 +132,7 @@ Each phase is handled by a dedicated AI agent. Artifacts are saved to `--output-
 | Item | Value |
 |------|-------|
 | Default model | `claude-sonnet-4-6` |
-| Python requirement | 3.11 or higher |
+| Python requirement | 3.12 or higher |
 | Auth method | Google Vertex AI (Application Default Credentials) |
 | Dashboard port | 8080 (local only) |
 | Dry run support | Yes - no credentials needed |


### PR DESCRIPTION
## Summary

Closes #101

- **New CLI reference** (`docs/user-guide/10-reference/cli.md`) — consolidates all CLI commands (`orchestrate.py`, `test_agents.py`, `publish.py`, `run_dashboard.py`, examples) in one page
- **New API reference** (`docs/user-guide/10-reference/api.md`) — REST API endpoints, heartbeat protocol, enricher pipeline, database schema, curl/Python examples
- **Dashboard-first quick-start** — simplified from 10 sections to 6, leads with `run_dashboard.py` + web UI, CLI usage links to reference page
- **Broken link fixes** across 7 files (`vertex-ai.md`, `api-key.md`, `04-publishing/publish.md` → correct paths)
- **README fixes** — duplicate Section 7 numbering, new Section 11 Reference, Code Flow in Advanced nav
- **Session management** — added stuck sessions cleanup endpoint and Clean stale sessions UI button docs
- **Python 3.12+** standardized across all docs
- **"four phases" → "five phases"** in agents-overview.md

## Files Changed

| File | Change |
|------|--------|
| `docs/user-guide/10-reference/cli.md` | New — CLI reference |
| `docs/user-guide/10-reference/api.md` | New — API reference |
| `docs/user-guide/01-getting-started/quick-start.md` | Rewritten — dashboard-first |
| `docs/user-guide/README.md` | Fixed — section numbering, new reference section |
| `docs/user-guide/01-getting-started/installation.md` | Fixed — Python 3.12+, broken link |
| `docs/user-guide/01-getting-started/configuration.md` | Fixed — broken link |
| `docs/user-guide/02-concepts/agents-overview.md` | Fixed — broken link, phase count |
| `docs/user-guide/04-dashboard/session-management.md` | Updated — stuck sessions, stale cleanup button |
| `docs/user-guide/06-advanced/dry-run-mode.md` | Fixed — broken link |
| `docs/user-guide/09-integrations/jira-rovo.md` | Fixed — broken link |

## Test plan

- [ ] Verify all internal doc links resolve (no 404s on GitHub)
- [ ] Confirm README section numbering is sequential (1–11)
- [ ] Check quick-start.md reads as dashboard-first flow
- [ ] Verify CLI and API reference pages render correctly
- [ ] Confirm stuck sessions cleanup section in session-management.md