### PR TITLE
refactor(docs): reposition messaging — SDLC orchestration identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Multi-agent AI system that automates design analysis and documentation generation for OpenShift/Shipwright Build projects. Uses Claude AI agents orchestrated by LangGraph in a sequential pipeline: Design → Development → Testing → Documentation.
+SDLC orchestration layer that automates the full feature development lifecycle for OpenShift/Shipwright Build projects. Uses Claude as the execution engine for stage-based workflows: Design → Development → Code Review → Testing → Documentation.
 
 ## Commands
 
@@ -36,9 +36,9 @@ uv run python scripts/test_agents.py --agent design --dry-run
 
 ## Architecture
 
-### LangGraph Workflow Pipeline (`agents/graph.py`)
+### Workflow Orchestrator (`agents/graph.py`)
 
-The orchestrator builds a `StateGraph` with four sequential nodes connected by conditional edges. Each node calls its agent, updates shared state, and emits a heartbeat to the dashboard. The `should_continue` function routes based on `current_phase` in state (e.g., `design_complete` → `develop`, `develop_complete` → `testing`). On error, the workflow terminates early via the `END` edge.
+The orchestrator builds a `StateGraph` (currently implemented using LangGraph) with five sequential stage nodes connected by conditional edges. Each node runs its stage, updates shared state, and emits a heartbeat to the dashboard. The `should_continue` function routes based on `current_phase` in state (e.g., `design_complete` → `develop`, `develop_complete` → `testing`). On error, the workflow terminates early via the `END` edge.
 
 ```
 design_node → develop_node → code_review_node → testing_node → docs_node → END
@@ -48,11 +48,11 @@ design_node → develop_node → code_review_node → testing_node → docs_node
 
 ### Shared State (`graph/state.py`)
 
-`AgentState` is a `TypedDict(total=False)` containing all fields shared across agents — inputs (issue title/description/type), outputs from each phase (design analysis, code files, test plans, PR summaries), control flow (session_id, current_phase, approval_status), and LangGraph messages with `add_messages` annotation.
+`AgentState` is a `TypedDict(total=False)` containing all fields shared across stages — inputs (issue title/description/type), outputs from each phase (design analysis, code files, test plans, PR summaries), control flow (session_id, current_phase, approval_status), and LangGraph messages with `add_messages` annotation.
 
-### Agent Pattern
+### Stage Pattern
 
-All five agents follow the same pattern:
+All five stage runners (currently named "agents" in code) follow the same pattern:
 1. Validate context/inputs
 2. Get Claude client via `config/auth_config.get_anthropic_client()`
 3. Build a prompt using system prompt from `config/agent_prompts.py` + user context
@@ -60,7 +60,7 @@ All five agents follow the same pattern:
 5. Parse the Markdown-structured response into typed dict outputs
 6. Emit heartbeat to dashboard
 
-| Agent | Entry Point | Key Input | Key Output |
+| Stage | Entry Point | Key Input | Key Output |
 |-------|------------|-----------|------------|
 | Design | `agents/design_agent.run_design()` | title, description, repo_path | design_analysis, impacted_components, risks, acceptance_criteria |
 | Development | `agents/go_k8s_developer.run_development()` | AgentState dict (needs implementation_plan as list) | code_files, test_files, pr_description |
@@ -70,16 +70,16 @@ All five agents follow the same pattern:
 
 ### Authentication (`config/auth_config.py`)
 
-Uses Google Vertex AI (`ANTHROPIC_VERTEX_PROJECT_ID`) for authentication. All agents use `get_anthropic_client()` which returns an `AnthropicVertex` client.
+Uses Google Vertex AI (`ANTHROPIC_VERTEX_PROJECT_ID`) for authentication. All stage runners use `get_anthropic_client()` which returns an `AnthropicVertex` client.
 
 ### Dashboard (`dashboard/`)
 
-FastAPI backend (`backend.py`) with SQLite storage at `/tmp/claude/dashboard.db`. Agents emit heartbeats via HTTP POST to `localhost:8080/api/heartbeat` using the `emit_heartbeat()` convenience function from `dashboard/heartbeat.py`. The `enrichers.py` module enriches raw heartbeat data before storage. Frontend is a single `dashboard/frontend/index.html`.
+FastAPI backend (`backend.py`) with SQLite storage at `/tmp/claude/dashboard.db`. Stage runners emit heartbeats via HTTP POST to `localhost:8080/api/heartbeat` using the `emit_heartbeat()` convenience function from `dashboard/heartbeat.py`. The `enrichers.py` module enriches raw heartbeat data before storage. Frontend is a single `dashboard/frontend/index.html`.
 
 ### Domain Configuration (`config/`)
 
 - `shipwright_components.py`: Shipwright Build component definitions (BuildRun, Build, BuildStrategy, webhooks), CRD types, build strategies, OpenShift integrations
-- `agent_prompts.py`: System prompts for each agent
+- `agent_prompts.py`: System prompts for each stage runner
 - `testing_config.py`: Ginkgo v2 test patterns and templates, pattern detection for build strategies/source types
 - `mock_responses.py`: Mock API responses for dry-run mode
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # FlowPilot: Feature SDLC Automation for Shipwright / OpenShift Builds
 
-AI-powered pipeline that automates the full feature development lifecycle — from Jira ticket to production-ready Go code, tests, and documentation.
+SDLC orchestration layer that drives a feature from Jira ticket to production-ready Go code, tests, and documentation — using Claude as the execution engine for every stage.
 
 ---
 
 ## What It Does
 
-You provide a Jira ticket (or a plain feature description). The system runs five AI agents through each phase of the software development lifecycle and delivers a complete set of artifacts: architecture design documents, production Go code, code review findings with an auto-fix loop, Ginkgo v2 test files, and PR-ready documentation. Each phase validates its outputs before passing state to the next agent, so failures surface immediately rather than propagating silently through the pipeline.
+You provide a Jira ticket (or a plain feature description). FlowPilot orchestrates five SDLC stages — each powered by Claude — and delivers a complete set of artifacts: architecture design documents, production Go code, code review findings with an auto-fix loop, Ginkgo v2 test files, and PR-ready documentation. Each stage validates its outputs before passing state to the next, so failures surface immediately rather than propagating silently through the pipeline.
 
 ---
 
@@ -28,7 +28,7 @@ You provide a Jira ticket (or a plain feature description). The system runs five
          Output: /output-dir with code/, tests/, design/, docs/
 ```
 
-The code review phase includes an auto-fix loop. Blocking findings route the pipeline back to the development agent for a retry, up to `MAX_REVIEW_ITERATIONS`:
+The code review stage includes an auto-fix loop. Blocking findings route the pipeline back to the development stage for a retry, up to `MAX_REVIEW_ITERATIONS`:
 
 ```text
 Development → Code Review ──PASS──→ Testing
@@ -42,7 +42,7 @@ Development → Code Review ──PASS──→ Testing
 
 ## SDLC Phase Details
 
-| Phase              | Agent               | Key Inputs                            | Key Outputs                                                                                 |
+| Phase              | Stage Runner        | Key Inputs                            | Key Outputs                                                                                 |
 | ------------------ | ------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------- |
 | 1 · Design         | Design Agent        | Jira ticket, repo paths               | Architecture analysis, impacted components, risks, acceptance criteria, implementation plan |
 | 2 · Development    | Development Agent   | Design analysis, implementation plan  | Go source files, PR description, API types                                                  |
@@ -55,7 +55,7 @@ Development → Code Review ──PASS──→ Testing
 
 ## Repository Support
 
-Configure repository paths so agents can analyze actual Go types, CRDs, and controllers from source. Use `repos.yaml` for multi-repo setups:
+Configure repository paths so stage runners can analyze actual Go types, CRDs, and controllers from source. Use `repos.yaml` for multi-repo setups:
 
 ```bash
 cp repos.yaml.example repos.yaml  # edit with your local clone paths
@@ -77,7 +77,7 @@ cp .env.example .env  # fill in credentials
 uv run python scripts/run_dashboard.py  # http://localhost:8080
 ```
 
-Open [http://localhost:8080](http://localhost:8080) and click **New Run**. Enter a Jira ticket ID (e.g. `BUILD-1707`) or a feature description, then click **Run Feature**. The pipeline runs all five phases and shows progress in real time.
+Open [http://localhost:8080](http://localhost:8080) and click **New Run**. Enter a Jira ticket ID (e.g. `BUILD-1707`) or a feature description, then click **Run Feature**. The pipeline orchestrates all five stages and shows progress in real time.
 
 For CLI and automation usage, see the [CLI Reference](docs/user-guide/10-reference/cli.md).
 
@@ -114,7 +114,7 @@ output/BUILD-1707/
 | [Quick Start](docs/user-guide/01-getting-started/quick-start.md) | Dashboard-first setup: install, configure credentials, run |
 | [Dashboard](docs/user-guide/04-dashboard/overview.md) | Web UI pages, real-time monitoring, session management |
 | [Architecture](docs/user-guide/02-concepts/architecture.md) | Pipeline design, state management, security layers |
-| [Agents](docs/user-guide/03-agents/design-agent.md) | Per-agent reference |
+| [Stage Runners](docs/user-guide/03-agents/design-agent.md) | Per-stage reference |
 | [CLI Reference](docs/user-guide/10-reference/cli.md) | All CLI commands for scripting and automation |
 | [API Reference](docs/user-guide/10-reference/api.md) | REST API endpoints, heartbeat protocol, database schema |
 | [Authentication](docs/user-guide/05-authentication/authentication.md) | Vertex AI setup |

--- a/docs/user-guide/02-concepts/agents-overview.md
+++ b/docs/user-guide/02-concepts/agents-overview.md
@@ -1,8 +1,8 @@
-# SDLC Agents
+# SDLC Pipeline Stages
 
-Each agent in the pipeline represents a distinct phase of the Feature Software Development Lifecycle (SDLC). A Jira ticket enters the system and flows sequentially through design, development, review, testing, and documentation before being published to GitHub and Jira.
+Each stage in the pipeline represents a distinct phase of the Feature Software Development Lifecycle (SDLC). A Jira ticket enters the system and flows sequentially through design, development, review, testing, and documentation before being published to GitHub and Jira. FlowPilot orchestrates the workflow; Claude serves as the execution engine for every stage.
 
-Agents do not call each other directly. They communicate through the shared `AgentState` dictionary managed by LangGraph. When an agent finishes, it returns a partial state update. LangGraph merges it into the full state, making all new fields immediately available to the next agent.
+Stages do not call each other directly. They communicate through the shared `AgentState` dictionary managed by the workflow orchestrator (currently implemented using LangGraph). When a stage completes, it returns a partial state update. The orchestrator merges it into the full state, making all new fields immediately available to the next stage.
 
 ---
 
@@ -104,9 +104,9 @@ For full parameter documentation, see the [Development Agent](../03-agents/devel
 
 **File:** `agents/code_review_agent.py`
 
-The Code Review Agent reviews generated Go code for quality, security, and correctness before it reaches the Testing Agent. It uses Claude (the same model as other agents — no extra installation needed) with an optional Qodo CLI integration via `QODO_CLI_PATH`.
+The Code Review Agent reviews generated Go code for quality, security, and correctness before it reaches the Testing stage. It uses Claude (the same model as other stages — no extra installation needed) with an optional Qodo CLI integration via `QODO_CLI_PATH`.
 
-**Auto-fix loop:** When blocking issues are found, the graph routes back to the Development Agent with the review findings injected into its prompt. The Development Agent fixes the issues and regenerates code. This loop repeats up to `MAX_REVIEW_ITERATIONS` times (default: 3). After max iterations, the pipeline continues to Testing regardless.
+**Auto-fix loop:** When blocking issues are found, the orchestrator routes back to the Development Agent with the review findings injected into its prompt. The Development Agent fixes the issues and regenerates code. This loop repeats up to `MAX_REVIEW_ITERATIONS` times (default: 3). After max iterations, the pipeline continues to Testing regardless.
 
 **Review domains:**
 
@@ -120,7 +120,7 @@ The Code Review Agent reviews generated Go code for quality, security, and corre
 
 | Tag | Effect |
 | --- | ------ |
-| `[BLOCKING]` | Triggers auto-fix loop back to Development Agent |
+| `[BLOCKING]` | Triggers auto-fix loop back to Development stage |
 | `[WARNING]` | Logged in summary, non-blocking |
 | `[SUGGESTION]` | Logged in summary, non-blocking |
 
@@ -135,7 +135,7 @@ The Code Review Agent reviews generated Go code for quality, security, and corre
 
 **Feature flag:** Set `QODO_REVIEW_ENABLED=false` to skip the review phase entirely (backward compatible).
 
-> **Note:** Unlike other phases, code review failures do not stop the workflow. Instead, they trigger the auto-fix loop back to the Development Agent. The validation result for this phase is always `passed=True`; review failures are surfaced as warnings in the phase summary.
+> **Note:** Unlike other stages, code review failures do not stop the workflow. Instead, they trigger the auto-fix loop back to the Development stage. The validation result for this stage is always `passed=True`; review failures are surfaced as warnings in the stage summary.
 
 For full parameter documentation, see the [Code Review Agent](../03-agents/code-review-agent.md) page.
 
@@ -174,7 +174,7 @@ For full parameter documentation, see the [Testing Agent](../03-agents/testing-a
 
 **File:** `agents/docs_agent.py`
 
-The Documentation Agent generates all documentation artifacts from the combined outputs of the previous four agents. It supports multiple output formats and can use RAG to pull in relevant existing documentation and code examples from the repository.
+The Documentation Agent generates all documentation artifacts from the combined outputs of the previous four stages. It supports multiple output formats and can use RAG to pull in relevant existing documentation and code examples from the repository.
 
 **Output formats:**
 
@@ -191,45 +191,45 @@ For full parameter documentation, see the [Docs Agent](../03-agents/docs-agent.m
 
 ## Publish
 
-After all five phases complete, `publish.py` pushes the generated code to a GitHub branch and posts results back to Jira.
+After all five stages complete, `publish.py` pushes the generated code to a GitHub branch and posts results back to Jira.
 
 See the [Publish](../09-integrations/publish.md) page for configuration and usage.
 
 ---
 
-## How Agents Connect
+## How Stages Connect
 
 ```text
-Design Agent writes → design_analysis, impacted_components, risks, acceptance_criteria
+Design stage writes → design_analysis, impacted_components, risks, acceptance_criteria
                              ↓
-Development Agent reads those fields, writes → code_files, test_files, pr_description
+Development stage reads those fields, writes → code_files, test_files, pr_description
                              ↓
-Code Review Agent reads code_files + design fields, writes → review_passed, review_findings
+Code Review stage reads code_files + design fields, writes → review_passed, review_findings
                     │                                        review_summary, review_iteration
                     │ (review_passed=False + iteration ≤ max)
-                    └──────────────────────────────────────────→ back to Development Agent
+                    └──────────────────────────────────────────→ back to Development stage
                     │                                            (with findings injected)
                     │ (review_passed=True OR iteration > max)
                     ↓
-Testing Agent reads design fields, writes → test_plan, unit_tests, integration_tests, e2e_tests
+Testing stage reads design fields, writes → test_plan, unit_tests, integration_tests, e2e_tests
                              ↓
-Docs Agent reads everything, writes → pr_summary, release_notes, ship_document, jtbd_documentation
+Docs stage reads everything, writes → pr_summary, release_notes, ship_document, jtbd_documentation
 ```
 
-The Testing Agent always has access to the original design analysis and the development agent's reviewed outputs. The Documentation Agent sees the complete picture from all four prior phases.
+The Testing stage always has access to the original design analysis and the development stage's reviewed outputs. The Documentation stage sees the complete picture from all four prior stages.
 
 ---
 
-## Validation Between Phases
+## Validation Between Stages
 
-After each agent completes, the orchestrator:
+After each stage completes, the orchestrator:
 
 1. **Validates outputs** — checks required fields are non-empty using `agents/validators.py`
-2. **Prints a phase summary** — shows key metrics and any warnings
+2. **Prints a stage summary** — shows key metrics and any warnings
 3. **Stops on failure** — if required fields are missing, the workflow stops immediately
-4. **Asks for approval** (if `MANUAL_APPROVAL=true`) — prompts `[Y/n]` before the next phase
+4. **Asks for approval** (if `MANUAL_APPROVAL=true`) — prompts `[Y/n]` before the next stage
 
-This ensures bad data from one agent never silently flows into the next agent.
+This ensures bad data from one stage never silently flows into the next stage.
 
 ---
 

--- a/docs/user-guide/02-concepts/architecture.md
+++ b/docs/user-guide/02-concepts/architecture.md
@@ -2,20 +2,20 @@
 
 ## Feature SDLC Pipeline
 
-The system automates the complete feature software development lifecycle (SDLC) — from a Jira ticket or issue description through to deployable artifacts — without manual handoffs between stages.
+FlowPilot is an SDLC orchestration layer that drives a feature from Jira ticket or issue description through to deployable artifacts — without manual handoffs between stages. Claude serves as the execution engine for every stage; FlowPilot supervises the workflow, validates outputs, and manages state transitions.
 
-Each run of `scripts/orchestrate.py` executes a fixed sequence of SDLC phases:
+Each run of `scripts/orchestrate.py` executes a fixed sequence of SDLC stages:
 
 ```
 Requirements → Design → Development → Code Review → Testing → Documentation → Publish
 ```
 
-The first phase (Requirements) is provided by the caller as an issue title and description. The remaining phases are carried out by specialized AI agents orchestrated by LangGraph. The final Publish step writes artifacts to disk via `publish.py`.
+The first stage (Requirements) is provided by the caller as an issue title and description. The remaining stages are carried out by stage runners — each powered by Claude — coordinated by the workflow orchestrator (currently implemented using LangGraph). The final Publish step writes artifacts to disk via `publish.py`.
 
-### SDLC Phase Overview
+### SDLC Stage Overview
 
-| Phase | SDLC Stage | Agent | Duration (typical) |
-| ----- | ---------- | ----- | ------------------ |
+| Phase | SDLC Stage | Stage Runner | Duration (typical) |
+| ----- | ---------- | ------------ | ------------------ |
 | 1 | Design & Architecture | Design Agent | ~90s |
 | 2 | Development | Development Agent | ~3min |
 | 2.5 | Code Review | Code Review Agent | ~45s (+ retry loop) |
@@ -35,7 +35,7 @@ The first phase (Requirements) is provided by the caller as an issue title and d
                                   │
                                   ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│                      LangGraph Orchestrator                         │
+│                      Workflow Orchestrator                           │
 │                      (agents/graph.py)                              │
 │                                                                     │
 │  ┌──────────┐  ┌──────────┐  ┌─────────────┐  ┌──────────┐  ┌──────┐  │
@@ -60,7 +60,7 @@ The first phase (Requirements) is provided by the caller as an issue title and d
 
 ## Pipeline Implementation
 
-The orchestrator (`agents/graph.py`) implements the SDLC phase sequence as a LangGraph `StateGraph` with five sequential nodes. Each node calls its agent, updates the shared `AgentState`, and emits a heartbeat to the dashboard. The `should_continue` router function reads `current_phase` from state to decide which SDLC phase runs next.
+The orchestrator (`agents/graph.py`) implements the SDLC stage sequence as a `StateGraph` (currently implemented using LangGraph) with five sequential stage nodes. Each node runs its stage, updates the shared `AgentState`, and emits a heartbeat to the dashboard. The `should_continue` router function reads `current_phase` from state to decide which SDLC stage runs next.
 
 ```
 design_node → develop_node → code_review_node → testing_node → docs_node → END
@@ -82,7 +82,7 @@ init → design_complete → develop_complete → review_complete → testing_co
                                           error
 ```
 
-When an agent raises an unhandled exception, the node sets `current_phase = "error"`, emits an error heartbeat, and the conditional router sends the workflow to `END`.
+When a stage runner raises an unhandled exception, the node sets `current_phase = "error"`, emits an error heartbeat, and the conditional router sends the workflow to `END`.
 
 ### Key Orchestrator Function
 
@@ -99,9 +99,9 @@ The orchestrator:
 
 ---
 
-## Agents at a Glance
+## Stage Runners at a Glance
 
-| Agent | File | Input | Output |
+| Stage | File | Input | Output |
 |-------|------|-------|--------|
 | Design | `agents/design_agent.py` | Issue title, description, optional repo path | Design document, component list, risks, acceptance criteria, implementation plan |
 | Development | `agents/go_k8s_developer.py` | Design outputs from state | Go code files, test files, PR description |
@@ -113,7 +113,7 @@ The orchestrator:
 
 ## Data Flow
 
-Each node returns a partial state dictionary. LangGraph merges it into the accumulated state so every subsequent agent automatically sees all prior outputs.
+Each node returns a partial state dictionary. The orchestrator merges it into the accumulated state so every subsequent stage automatically sees all prior outputs.
 
 ```
 orchestrate() creates initial state
@@ -162,14 +162,14 @@ Final state returned to caller
 
 ## Output Validation Gates
 
-After each agent completes, its outputs are validated before the next phase begins.
-This prevents silent cascading failures where an agent returns empty data and
-subsequent agents produce garbage outputs.
+After each stage completes, its outputs are validated before the next stage begins.
+This prevents silent cascading failures where a stage returns empty data and
+subsequent stages produce garbage outputs.
 
 **Validation flow:**
 
 ```text
-Agent completes
+Stage completes
      ↓
 validate_phase(phase, state)
      ↓
@@ -177,7 +177,7 @@ validate_phase(phase, state)
 PASS    FAIL
   ↓      ↓
 Next   Stop workflow with
-Phase  clear error message
+Stage  clear error message
 ```
 
 **Validation rules per phase:**
@@ -204,7 +204,7 @@ result = validate_phase("design", state)
 # result.summary  → dict       (key metrics, e.g. "Code files generated: 3")
 ```
 
-**Extending validation:** To add a validator for a new agent phase, add a
+**Extending validation:** To add a validator for a new stage, add a
 `validate_<phase>_output(state)` function in `agents/validators.py` and register
 it in the `VALIDATORS` dict. The orchestrator picks it up automatically via
 `validate_phase()`.
@@ -219,7 +219,7 @@ configuration, and manual approval mode.
 
 ### PII Redaction
 
-All data fetched from external sources (Jira tickets, GitHub PRs) is redacted before it enters the agent pipeline. Redaction happens inside the fetch functions themselves — `JiraClient.fetch_ticket()` and `GitHubClient.fetch_pr()` — so PII never appears in workflow state, agent prompts, or dashboard heartbeats.
+All data fetched from external sources (Jira tickets, GitHub PRs) is redacted before it enters the pipeline. Redaction happens inside the fetch functions themselves — `JiraClient.fetch_ticket()` and `GitHubClient.fetch_pr()` — so PII never appears in workflow state, agent prompts, or dashboard heartbeats.
 
 **What is redacted:**
 
@@ -234,9 +234,9 @@ See [PII Redaction](../07-security/pii-redaction.md) for the full reference.
 
 ### Prompt Injection Guard
 
-External free-text fields (issue titles, descriptions, PR bodies) are sanitized inside each agent before the text is embedded into a Claude prompt. The guard strips five categories of injection patterns: role overrides, system-escape sequences, jailbreak tokens, base64-encoded payloads, and delimiter abuse.
+External free-text fields (issue titles, descriptions, PR bodies) are sanitized inside each stage runner before the text is embedded into a Claude prompt. The guard strips five categories of injection patterns: role overrides, system-escape sequences, jailbreak tokens, base64-encoded payloads, and delimiter abuse.
 
-Sanitization runs at the agent layer — after PII redaction but before prompt assembly — so injected instructions in external content never reach the model.
+Sanitization runs at the stage-runner layer — after PII redaction but before prompt assembly — so injected instructions in external content never reach the model.
 
 **Audit logging:** When a pattern is matched, a `WARNING` log line records the category and source field only. The matched content is never logged.
 
@@ -306,13 +306,13 @@ Dashboard: http://localhost:8080
 
 ### Dashboard
 
-The dashboard (`dashboard/backend.py`) is an optional FastAPI server with SQLite storage. Agents emit heartbeats via HTTP POST to `/api/heartbeat`. If the dashboard is unreachable, heartbeats fail silently so the workflow is not blocked.
+The dashboard (`dashboard/backend.py`) is an optional FastAPI server with SQLite storage. Stage runners emit heartbeats via HTTP POST to `/api/heartbeat`. If the dashboard is unreachable, heartbeats fail silently so the workflow is not blocked.
 
 See [Dashboard Overview](../04-dashboard/overview.md).
 
 ### Skills Layer
 
-The `skills/` package is a thin, uniform wrapper over the external integrations in `tools/`. Skills are called exclusively from entry points (`scripts/orchestrate.py`, `scripts/test_agents.py`) — agents in the pipeline do not call skills directly.
+The `skills/` package is a thin, uniform wrapper over the external integrations in `tools/`. Skills are called exclusively from entry points (`scripts/orchestrate.py`, `scripts/test_agents.py`) — stage runners in the pipeline do not call skills directly.
 
 **Key design properties:**
 
@@ -331,7 +331,7 @@ The `skills/` package is a thin, uniform wrapper over the external integrations 
 
 ### Repository Analysis Tools
 
-Optional tools in `tools/` that agents can use when a repository path is provided:
+Optional tools in `tools/` that stage runners can use when a repository path is provided:
 
 - `tools/repo_search.py` - Code search and Go package analysis
 - `tools/rag_search.py` - Documentation search with RAG for the docs agent
@@ -342,26 +342,26 @@ Optional tools in `tools/` that agents can use when a repository path is provide
 ### Configuration
 
 - `config/shipwright_components.py` - Shipwright Build component definitions (BuildRun, Build, BuildStrategy, webhooks), CRD types, build strategies, OpenShift integrations
-- `config/agent_prompts.py` - System prompts for each agent
+- `config/agent_prompts.py` - System prompts for each stage runner
 - `config/testing_config.py` - Ginkgo v2 test patterns and templates
 - `config/mock_responses.py` - Mock API responses for dry run mode
 - `config/redaction_config.py` - Public domain allowlist for PII redaction
 
-### Agent Prompts (`config/agent_prompts.py`)
+### Stage Prompts (`config/agent_prompts.py`)
 
-Each agent has a dedicated system prompt stored as a `Final[str]` constant in `config/agent_prompts.py`. The prompt defines the agent's role, responsibilities, output format, and guardrails.
+Each stage runner has a dedicated system prompt stored as a `Final[str]` constant in `config/agent_prompts.py`. The prompt defines the stage's role, responsibilities, output format, and guardrails.
 
 | Constant | Used by | Purpose |
 | -------- | ------- | ------- |
-| `DESIGN_AGENT_PROMPT` | `agents/design_agent.py` | Instructs the agent to produce design documents: problem statement, scope, impacted components, risks, acceptance criteria, implementation plan |
-| `DEVELOPMENT_AGENT_PROMPT` | `agents/go_k8s_developer.py` | Instructs the agent to generate idiomatic Go code, table-driven tests, and a PR description ending with "Generated by AI" |
+| `DESIGN_AGENT_PROMPT` | `agents/design_agent.py` | Instructs Claude to produce design documents: problem statement, scope, impacted components, risks, acceptance criteria, implementation plan |
+| `DEVELOPMENT_AGENT_PROMPT` | `agents/go_k8s_developer.py` | Instructs Claude to generate idiomatic Go code, table-driven tests, and a PR description ending with "Generated by AI" |
 | `CODE_REVIEW_AGENT_PROMPT` | `agents/code_review_agent.py` | Instructs Claude to review generated Go code using machine-parseable `[BLOCKING]`/`[WARNING]`/`[SUGGESTION]` format, ending with `VERDICT: PASS` or `VERDICT: FAIL` |
-| `TESTING_AGENT_PROMPT` | `agents/testing_agent.py` | Instructs the agent to generate Ginkgo v2 test suites with DDT patterns, Gomega assertions, and Shipwright test helpers |
-| `DOCS_AGENT_PROMPT` | `agents/docs_agent.py` | Instructs the agent to produce PR summaries, release notes, JTBD documentation, SHIP documents, and high-level design documents |
+| `TESTING_AGENT_PROMPT` | `agents/testing_agent.py` | Instructs Claude to generate Ginkgo v2 test suites with DDT patterns, Gomega assertions, and Shipwright test helpers |
+| `DOCS_AGENT_PROMPT` | `agents/docs_agent.py` | Instructs Claude to produce PR summaries, release notes, JTBD documentation, SHIP documents, and high-level design documents |
 
-**How agents load their prompt:**
+**How stage runners load their prompt:**
 
-Each agent imports its constant at the top of the module and passes it as the `system` parameter of the Claude API call:
+Each stage runner imports its constant at the top of the module and passes it as the `system` parameter of the Claude API call:
 
 ```python
 from config.agent_prompts import DESIGN_AGENT_PROMPT
@@ -375,7 +375,7 @@ response = client.messages.create(
 
 **Customizing prompts:**
 
-To adjust agent behavior, edit the relevant constant in `config/agent_prompts.py`. Common reasons to customize:
+To adjust stage behavior, edit the relevant constant in `config/agent_prompts.py`. Common reasons to customize:
 
 - Change the output format (e.g., switch from Markdown to JSON)
 - Add project-specific guardrails (e.g., enforce a naming convention)
@@ -390,7 +390,7 @@ Changes take effect immediately on the next run — no code changes required.
 
 ```text
 muilti-agents-ocp-builds/
-├── agents/          # Agent implementations, LangGraph graph, output validators
+├── agents/          # Stage runner implementations, workflow orchestrator, output validators
 ├── config/          # Prompts, auth, patterns, mock data
 ├── dashboard/       # FastAPI backend, enrichers, heartbeat, frontend
 ├── graph/           # AgentState schema (state.py)


### PR DESCRIPTION
## Summary
- Replace "multi-agent framework" / "agent platform" language with "SDLC orchestration layer" across README, CLAUDE.md, and docs
- Rename "Agent" references to "Stage Runner" / "Stage" where appropriate
- Clarify Claude as execution engine, FlowPilot as supervisor
- Update architecture diagrams from "LangGraph Orchestrator" to "Workflow Orchestrator"

Closes #103

## Files Changed
- `README.md` — project tagline, phase table headers
- `CLAUDE.md` — project overview, section headings
- `docs/user-guide/02-concepts/architecture.md` — orchestrator terminology
- `docs/user-guide/02-concepts/agents-overview.md` — page title, section headings

## Test plan
- [ ] Verify no broken links in docs
- [ ] Confirm README renders correctly on GitHub
- [ ] No code changes — messaging only