### PR TITLE
refactor: add Pydantic output validation to all SDLC stages

### DIFF
--- a/agents/design_agent.py
+++ b/agents/design_agent.py
@@ -14,6 +14,7 @@ from typing import Dict, Any, Optional
 
 from config.agent_prompts import DESIGN_AGENT_PROMPT
 from config.auth_config import get_anthropic_client
+from models.stage_outputs import DesignOutput
 from utils.file_logger import get_logger
 from config.shipwright_components import (
     get_component_info,
@@ -131,13 +132,24 @@ def run_design(title: str, description: str, repo_path: Optional[str] = None) ->
     parsed_result = _parse_design_output(design_text)
     logger.info(f"Design analysis completed successfully. Found {len(parsed_result.get('impacted_components', []))} impacted components")
 
-    return {
+    result = {
         "design_analysis": design_text,
         "impacted_components": parsed_result.get("impacted_components", []),
         "risks": parsed_result.get("risks", []),
         "acceptance_criteria": parsed_result.get("acceptance_criteria", []),
         "implementation_plan": parsed_result.get("implementation_plan", []),
     }
+
+    # Validate with Pydantic model (non-blocking -- log warnings, don't fail)
+    # TODO: When claude_agent_sdk is available on PyPI, swap to SDK query()
+    # with output_format=DesignOutput for native structured output.
+    try:
+        DesignOutput.model_validate(result)
+        logger.debug("Design output passed Pydantic validation")
+    except Exception as e:
+        logger.warning(f"Design output Pydantic validation warning: {e}")
+
+    return result
 
 
 # Repository search patterns by project type

--- a/agents/docs_agent.py
+++ b/agents/docs_agent.py
@@ -20,6 +20,7 @@ from anthropic import APIError
 
 from config.agent_prompts import DOCS_AGENT_PROMPT
 from config.auth_config import get_anthropic_client
+from models.stage_outputs import DocsOutput
 from tools.prompt_guard import sanitize_external_input
 from tools.rag_search import RAGSearch, RAGSearchError
 from utils.file_logger import get_logger, get_session_logger
@@ -161,6 +162,27 @@ def run_docs(
         # Parse structured output
         logger.debug("Parsing documentation response")
         docs_output = _parse_docs_response(response_text, output_format)
+
+        # Validate core fields with Pydantic model (non-blocking -- log warnings, don't fail).
+        # The full docs_output dict has extra fields (pr_description, input_files_analyzed,
+        # rag_enabled, output_format) not in DocsOutput.  We validate the contract-relevant subset.
+        # TODO: When claude_agent_sdk is available on PyPI, swap to SDK query()
+        # with output_format=DocsOutput for native structured output.
+        try:
+            validation_data = {
+                "pr_summary": docs_output.get("pr_summary", ""),
+                "release_notes": docs_output.get("release_notes", ""),
+                "docs_changes": docs_output.get("docs_changes", {}),
+                "upgrade_notes": docs_output.get("upgrade_notes", ""),
+                "known_limitations": docs_output.get("known_limitations", ""),
+                "jtbd_documentation": docs_output.get("jtbd_documentation", ""),
+                "ship_document": docs_output.get("ship_document", ""),
+                "high_level_design": docs_output.get("high_level_design", ""),
+            }
+            DocsOutput.model_validate(validation_data)
+            logger.debug("Docs output passed Pydantic validation")
+        except Exception as e:
+            logger.warning(f"Docs output Pydantic validation warning: {e}")
 
         # Add metadata about processing
         docs_output["input_files_analyzed"] = input_files or []

--- a/agents/go_k8s_developer.py
+++ b/agents/go_k8s_developer.py
@@ -23,6 +23,7 @@ except ImportError:
 from config.agent_prompts import DEVELOPMENT_AGENT_PROMPT
 from config.auth_config import get_anthropic_client
 from dashboard.heartbeat import emit_heartbeat
+from models.stage_outputs import DevelopOutput
 from tools.prompt_guard import sanitize_external_input
 from tools.repo_search import RepoSearch
 from utils.file_logger import get_logger, get_session_logger
@@ -180,7 +181,7 @@ def run_development(
     logger.info(f"Development agent completed successfully. Generated {files_generated} files")
     session_logger.info(f"Development complete: {files_generated} files generated")
 
-    return {
+    result = {
         "code_files": parsed_result.get("code_files", []),
         "test_files": parsed_result.get("test_files", []),
         "code_changes": code_changes,
@@ -191,6 +192,32 @@ def run_development(
         "next_steps": parsed_result.get("next_steps", []),
         "raw_output": dev_output,  # Include raw output for debugging
     }
+
+    # Validate core fields with Pydantic model (non-blocking -- log warnings, don't fail).
+    # The full result dict has extra fields (code_changes, files_modified, next_steps,
+    # raw_output) and slight key differences (dependencies vs new_dependencies,
+    # security_notes as list vs str) compared to DevelopOutput.  We map the
+    # overlapping subset for contract validation.
+    # TODO: When claude_agent_sdk is available on PyPI, swap to SDK query()
+    # with output_format=DevelopOutput for native structured output.
+    try:
+        validation_data = {
+            "code_files": result["code_files"],
+            "test_files": result["test_files"],
+            "pr_description": result["pr_description"],
+            "security_notes": (
+                "\n".join(result["security_notes"])
+                if isinstance(result["security_notes"], list)
+                else result["security_notes"]
+            ),
+            "new_dependencies": result["dependencies"],
+        }
+        DevelopOutput.model_validate(validation_data)
+        logger.debug("Development output passed Pydantic validation")
+    except Exception as e:
+        logger.warning(f"Development output Pydantic validation warning: {e}")
+
+    return result
 
 
 def _synthesize_file_tracking(code_files: List[dict], test_files: List[dict]) -> tuple:

--- a/agents/testing_agent.py
+++ b/agents/testing_agent.py
@@ -16,6 +16,7 @@ import yaml
 
 from config.agent_prompts import TESTING_AGENT_PROMPT
 from config.auth_config import get_anthropic_client
+from models.stage_outputs import TestingOutput
 from tools.output_sanitizer import sanitize
 from tools.prompt_guard import sanitize_external_input
 from utils.file_logger import get_logger, get_session_logger
@@ -165,6 +166,25 @@ def run_testing(context: Dict[str, Any], output_dir: Optional[Path] = None) -> D
         "patterns_detected": patterns_detected,
         "raw_output": test_output,  # Include raw output for debugging
     }
+
+    # Validate core fields with Pydantic model (non-blocking -- log warnings, don't fail).
+    # The full result dict has extra fields (test_summary, patterns_detected, raw_output)
+    # not in TestingOutput.  We validate only the contract-relevant subset.
+    # TODO: When claude_agent_sdk is available on PyPI, swap to SDK query()
+    # with output_format=TestingOutput for native structured output.
+    try:
+        validation_data = {
+            "test_plan": result["test_plan"],
+            "test_specifications": result["test_specifications"],
+            "unit_tests": result["unit_tests"],
+            "integration_tests": result["integration_tests"],
+            "e2e_tests": result["e2e_tests"],
+            "coverage_analysis": result["coverage_analysis"],
+        }
+        TestingOutput.model_validate(validation_data)
+        logger.debug("Testing output passed Pydantic validation")
+    except Exception as e:
+        logger.warning(f"Testing output Pydantic validation warning: {e}")
 
     # Resolve output directory and write artifacts
     resolved_output_dir = output_dir if output_dir is not None else Path("/tmp/claude/testing-artifacts")


### PR DESCRIPTION
## Summary
- Add Pydantic output validation to all 4 SDLC stages using models from `models/stage_outputs.py`
- Validation is non-blocking (logs warnings, never fails the pipeline)
- Each validation site has a TODO for future Agent SDK swap when `claude_agent_sdk` becomes available on PyPI
- Zero test regressions (148 tests pass, 4 skipped, 3 pre-existing failures in testing validator)

Closes #108

## Files Changed
- `agents/design_agent.py` — Added `DesignOutput` validation
- `agents/go_k8s_developer.py` — Added `DevelopOutput` validation with field mapping
- `agents/testing_agent.py` — Added `TestingOutput` validation
- `agents/docs_agent.py` — Added `DocsOutput` validation

## Test plan
- [ ] `uv run pytest tests/ -v` — no regressions
- [ ] Verify validation is non-blocking (warning log only)
- [ ] Confirm function signatures unchanged