### PR TITLE
refactor: extend repo.yaml schema — stages, approvals, prompt overrides

### DIFF
--- a/config/repo_schema.py
+++ b/config/repo_schema.py
@@ -1,8 +1,8 @@
 """Pydantic schema for repos.yaml configuration.
 
 Defines the structure and validation rules for repository entries,
-including optional language and per-repo build/lint/test/doc commands.
-Stages, approvals, and overrides are deferred to a later iteration.
+including optional language and per-repo build/lint/test/doc commands,
+workflow stage ordering, approval requirements, and prompt overrides.
 """
 
 from __future__ import annotations
@@ -10,6 +10,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from pydantic import BaseModel, field_validator
+
+VALID_STAGES = ["design", "develop", "testing", "docs"]
 
 
 class RepoCommands(BaseModel):
@@ -36,7 +38,51 @@ class RepoEntry(BaseModel):
         return v
 
 
+class ApprovalConfig(BaseModel):
+    """Approval requirements for workflow stages."""
+
+    required_stages: list[str] = []
+    auto_approve: bool = False
+
+    @field_validator("required_stages")
+    @classmethod
+    def validate_stage_names(cls, v: list[str]) -> list[str]:
+        for stage in v:
+            if stage not in VALID_STAGES:
+                raise ValueError(
+                    f"Invalid stage name '{stage}'. Valid: {VALID_STAGES}"
+                )
+        return v
+
+
+class PromptOverrides(BaseModel):
+    """Optional prompt overrides per stage.
+
+    When set, these replace the default system prompts.
+    """
+
+    design: str | None = None
+    develop: str | None = None
+    test: str | None = None
+    docs: str | None = None
+
+
 class RepoConfig(BaseModel):
     """Top-level repos.yaml schema."""
 
     repos: list[RepoEntry] = []
+    stages: list[str] = VALID_STAGES.copy()
+    approvals: ApprovalConfig = ApprovalConfig()
+    prompts: PromptOverrides = PromptOverrides()
+
+    @field_validator("stages")
+    @classmethod
+    def validate_stages(cls, v: list[str]) -> list[str]:
+        for stage in v:
+            if stage not in VALID_STAGES:
+                raise ValueError(
+                    f"Invalid stage '{stage}'. Valid: {VALID_STAGES}"
+                )
+        if len(v) != len(set(v)):
+            raise ValueError("Duplicate stages not allowed")
+        return v

--- a/repos.yaml.example
+++ b/repos.yaml.example
@@ -74,3 +74,47 @@ repos:
   # Custom repos — add any Git repository you want agents to analyze
   # --------------------------------------------------------------------------
   # - path: /home/user/git/my-org/my-repo
+
+
+# ============================================================================
+# Stage Configuration
+# ============================================================================
+# Ordered list of enabled stages (default: all four).
+# Remove a stage to skip it entirely; reorder to change execution sequence.
+#
+# stages:
+#   - design
+#   - develop
+#   - testing
+#   - docs
+#
+# Skip testing stage:
+# stages:
+#   - design
+#   - develop
+#   - docs
+
+
+# ============================================================================
+# Approval Requirements
+# ============================================================================
+# Control which stages pause for manual approval before proceeding.
+#
+# approvals:
+#   required_stages:        # Stages that pause for manual approval
+#     - develop
+#     - testing
+#   auto_approve: false     # Set true to skip all approval prompts
+
+
+# ============================================================================
+# Prompt Overrides
+# ============================================================================
+# Replace default system prompts for individual stages.
+# Only the stages you specify are overridden; others keep their defaults.
+#
+# prompts:
+#   design: "You are a security-focused design analyst..."
+#   develop: "You are a Python developer. Generate Django code..."
+#   test: "Generate pytest tests with 90% coverage target..."
+#   docs: "Generate documentation in AsciiDoc format..."

--- a/tests/test_repo_schema.py
+++ b/tests/test_repo_schema.py
@@ -9,7 +9,14 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from config.repo_schema import RepoCommands, RepoConfig, RepoEntry
+from config.repo_schema import (
+    ApprovalConfig,
+    PromptOverrides,
+    RepoCommands,
+    RepoConfig,
+    RepoEntry,
+    VALID_STAGES,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -239,3 +246,205 @@ class TestLoadRepoConfig:
         paths = load_repo_paths(project_root=str(tmp_path))
         assert len(paths) == 1
         assert paths[0] == str(repo_dir.resolve())
+
+
+# ---------------------------------------------------------------------------
+# Stages
+# ---------------------------------------------------------------------------
+
+
+class TestStages:
+    """Stage ordering configuration tests."""
+
+    def test_default_stages(self) -> None:
+        config = RepoConfig()
+        assert config.stages == ["design", "develop", "testing", "docs"]
+
+    def test_default_stages_match_constant(self) -> None:
+        config = RepoConfig()
+        assert config.stages == VALID_STAGES
+
+    def test_custom_stage_order(self) -> None:
+        config = RepoConfig(stages=["design", "develop", "docs"])
+        assert config.stages == ["design", "develop", "docs"]
+
+    def test_invalid_stage_name(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid stage"):
+            RepoConfig(stages=["design", "invalid_stage"])
+
+    def test_duplicate_stages(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate stages"):
+            RepoConfig(stages=["design", "design", "develop"])
+
+    def test_empty_stages(self) -> None:
+        config = RepoConfig(stages=[])
+        assert config.stages == []
+
+    def test_single_stage(self) -> None:
+        config = RepoConfig(stages=["docs"])
+        assert config.stages == ["docs"]
+
+    def test_reversed_order(self) -> None:
+        config = RepoConfig(stages=["docs", "testing", "develop", "design"])
+        assert config.stages == ["docs", "testing", "develop", "design"]
+
+
+# ---------------------------------------------------------------------------
+# ApprovalConfig
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalConfig:
+    """Approval requirements tests."""
+
+    def test_default_approvals(self) -> None:
+        config = RepoConfig()
+        assert config.approvals.required_stages == []
+        assert config.approvals.auto_approve is False
+
+    def test_required_stages(self) -> None:
+        config = RepoConfig(approvals={"required_stages": ["develop", "testing"]})
+        assert config.approvals.required_stages == ["develop", "testing"]
+
+    def test_auto_approve(self) -> None:
+        config = RepoConfig(approvals={"auto_approve": True})
+        assert config.approvals.auto_approve is True
+
+    def test_invalid_approval_stage(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid stage name"):
+            RepoConfig(approvals={"required_stages": ["nonexistent"]})
+
+    def test_approval_config_standalone(self) -> None:
+        approval = ApprovalConfig(required_stages=["design"], auto_approve=True)
+        assert approval.required_stages == ["design"]
+        assert approval.auto_approve is True
+
+    def test_approval_config_empty(self) -> None:
+        approval = ApprovalConfig()
+        assert approval.required_stages == []
+        assert approval.auto_approve is False
+
+
+# ---------------------------------------------------------------------------
+# PromptOverrides
+# ---------------------------------------------------------------------------
+
+
+class TestPromptOverrides:
+    """Prompt override tests."""
+
+    def test_default_prompts(self) -> None:
+        config = RepoConfig()
+        assert config.prompts.design is None
+        assert config.prompts.develop is None
+        assert config.prompts.test is None
+        assert config.prompts.docs is None
+
+    def test_custom_prompts(self) -> None:
+        config = RepoConfig(prompts={"design": "Custom design prompt"})
+        assert config.prompts.design == "Custom design prompt"
+        assert config.prompts.develop is None
+
+    def test_all_prompts(self) -> None:
+        config = RepoConfig(
+            prompts={
+                "design": "Design prompt",
+                "develop": "Develop prompt",
+                "test": "Test prompt",
+                "docs": "Docs prompt",
+            }
+        )
+        assert config.prompts.design == "Design prompt"
+        assert config.prompts.develop == "Develop prompt"
+        assert config.prompts.test == "Test prompt"
+        assert config.prompts.docs == "Docs prompt"
+
+    def test_prompt_overrides_standalone(self) -> None:
+        overrides = PromptOverrides(design="Custom", test="Also custom")
+        assert overrides.design == "Custom"
+        assert overrides.test == "Also custom"
+        assert overrides.develop is None
+        assert overrides.docs is None
+
+
+# ---------------------------------------------------------------------------
+# Full YAML round-trip via load_repo_config
+# ---------------------------------------------------------------------------
+
+
+class TestFullConfigYaml:
+    """End-to-end YAML parsing with new schema fields."""
+
+    def test_full_config_from_yaml(self, tmp_path: Path) -> None:
+        from config.repo_config import load_repo_config
+
+        yaml_content = dedent("""\
+            repos:
+              - path: /tmp/test-repo
+            stages:
+              - design
+              - develop
+            approvals:
+              required_stages:
+                - develop
+              auto_approve: false
+            prompts:
+              design: "Custom design prompt"
+        """)
+        yaml_file = tmp_path / "repos.yaml"
+        yaml_file.write_text(yaml_content)
+
+        config = load_repo_config(yaml_file)
+        assert len(config.repos) == 1
+        assert config.stages == ["design", "develop"]
+        assert config.approvals.required_stages == ["develop"]
+        assert config.approvals.auto_approve is False
+        assert config.prompts.design == "Custom design prompt"
+
+    def test_yaml_with_only_repos_keeps_defaults(self, tmp_path: Path) -> None:
+        from config.repo_config import load_repo_config
+
+        yaml_content = dedent("""\
+            repos:
+              - path: /tmp/test-repo
+        """)
+        yaml_file = tmp_path / "repos.yaml"
+        yaml_file.write_text(yaml_content)
+
+        config = load_repo_config(yaml_file)
+        assert config.stages == VALID_STAGES
+        assert config.approvals.required_stages == []
+        assert config.approvals.auto_approve is False
+        assert config.prompts.design is None
+
+    def test_yaml_invalid_stage_returns_empty(self, tmp_path: Path) -> None:
+        from config.repo_config import load_repo_config
+
+        yaml_content = dedent("""\
+            repos:
+              - path: /tmp/test-repo
+            stages:
+              - design
+              - bogus
+        """)
+        yaml_file = tmp_path / "repos.yaml"
+        yaml_file.write_text(yaml_content)
+
+        config = load_repo_config(yaml_file)
+        # Validation failure falls back to empty config
+        assert config.repos == []
+
+    def test_yaml_auto_approve_only(self, tmp_path: Path) -> None:
+        from config.repo_config import load_repo_config
+
+        yaml_content = dedent("""\
+            repos: []
+            approvals:
+              auto_approve: true
+        """)
+        yaml_file = tmp_path / "repos.yaml"
+        yaml_file.write_text(yaml_content)
+
+        config = load_repo_config(yaml_file)
+        assert config.approvals.auto_approve is True
+        assert config.approvals.required_stages == []


### PR DESCRIPTION
## Summary
- Add `stages` field to `RepoConfig` — ordered list of enabled stages (default: all four)
- Add `ApprovalConfig` model — `required_stages` and `auto_approve` fields
- Add `PromptOverrides` model — optional per-stage prompt overrides
- All fields validated against `VALID_STAGES` constant
- 22 new tests (44 total in schema tests), all passing
- `load_repo_config()` handles new fields automatically via Pydantic

Closes #115

## Files Changed
- `config/repo_schema.py` — Extended with `ApprovalConfig`, `PromptOverrides`, stage validation
- `repos.yaml.example` — Added documented examples for new fields
- `tests/test_repo_schema.py` — 22 new tests

## Test plan
- [ ] `uv run pytest tests/test_repo_schema.py -v` — 44 tests pass
- [ ] `uv run pytest tests/ -v` — no regressions
- [ ] Verify YAML round-trip with all new fields