### PR TITLE
refactor: demote Code Review from stage to quality gate

### DIFF
--- a/agents/code_review_agent.py
+++ b/agents/code_review_agent.py
@@ -1,11 +1,14 @@
-"""Code Review Agent with auto-fix loop support.
+"""Code review agent --- now called via orchestrator/gates.py review gate.
+
+This module is kept as the implementation behind the review quality gate.
+It is no longer a standalone SDLC stage.
 
 Uses Claude to review generated Go code for quality, security, and correctness.
 Optionally integrates with Qodo CLI when QODO_CLI_PATH is set.
 
 Auto-fix loop: when blocking issues are found, sets review_passed=False so
-the LangGraph router sends the workflow back to the Development Agent with
-review feedback injected into the prompt. Repeats up to MAX_REVIEW_ITERATIONS.
+the orchestrator re-runs the Development stage with review feedback injected
+into the prompt. Repeats up to MAX_REVIEW_ITERATIONS.
 
 Environment variables:
     QODO_REVIEW_ENABLED: Set to 'false' to skip review (default: 'true')

--- a/orchestrator/gates.py
+++ b/orchestrator/gates.py
@@ -1,0 +1,30 @@
+"""Quality gates for the SDLC workflow.
+
+Gates run between stages to enforce quality standards. Unlike stages,
+gates don't produce new artifacts --- they validate existing outputs
+and return pass/fail decisions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from utils.file_logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def run_review_gate(state: dict[str, Any]) -> dict[str, Any]:
+    """Run code review as a quality gate after the Develop stage.
+
+    Wraps the existing code_review_agent logic. This is a gate, not a stage.
+
+    Args:
+        state: Workflow state with code_files, design_analysis, etc.
+
+    Returns:
+        Dict with review_passed, review_findings, review_summary, review_iteration
+    """
+    from agents.code_review_agent import run_code_review
+
+    return run_code_review(state)

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -1,16 +1,18 @@
 """Thin sequential stage runner replacing the LangGraph StateGraph orchestrator.
 
-Executes the pipeline: Design -> Develop -> Code Review (with retry loop) -> Testing -> Docs.
+Executes the pipeline: Design -> Develop (with review gate) -> Testing -> Docs.
 Each stage merges its result into shared state, emits a heartbeat, and validates output
 before proceeding to the next stage.
+
+Code Review is not a standalone stage; it runs as a quality gate after
+Develop via :func:`orchestrator.gates.run_review_gate`.
 """
 
 from __future__ import annotations
 
 import os
-import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 
 # Maximum code-review retry iterations (develop -> review loop).
@@ -98,9 +100,81 @@ class WorkflowOrchestrator:
         from agents.go_k8s_developer import run_development
         return run_development(state, repo_path=state.get("repo_path"))
 
-    def _run_code_review(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        from agents.code_review_agent import run_code_review
-        return run_code_review(state)
+    def _run_develop_with_review_gate(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Run development followed by the review quality gate.
+
+        Implements the develop + review-gate loop:
+        1. Run development stage
+        2. Run review gate
+        3. If review fails and iterations remain, re-run develop with findings
+        4. Return combined state updates
+
+        Args:
+            state: Current workflow state (mutated in-place).
+
+        Returns:
+            The mutated *state* dict.  On error ``state["current_phase"]``
+            is set to ``"error"``.
+        """
+        from orchestrator.gates import run_review_gate
+
+        # --- initial development run ---
+        try:
+            result = self._run_develop(state)
+            state.update(result)
+            state["current_phase"] = "develop_complete"
+            self._emit_heartbeat("develop", state)
+        except Exception as e:
+            state["current_phase"] = "error"
+            state["error"] = f"Development stage failed: {e}"
+            self._emit_heartbeat("develop", state)
+            return state
+
+        if not self._validate("develop", state):
+            state["current_phase"] = "error"
+            state["error"] = "Development validation failed"
+            self._emit_heartbeat("develop", state)
+            return state
+
+        # --- review gate with retry loop ---
+        max_iterations = _get_max_review_iterations()
+        review_iteration = 0
+
+        while review_iteration < max_iterations:
+            review_iteration += 1
+
+            try:
+                result = run_review_gate(state)
+                state.update(result)
+                state["current_phase"] = "review_complete"
+                self._emit_heartbeat("review_gate", state)
+            except Exception as e:
+                state["current_phase"] = "error"
+                state["error"] = f"Review gate failed: {e}"
+                self._emit_heartbeat("review_gate", state)
+                return state
+
+            self._validate("code_review", state)
+
+            if state.get("review_passed", True):
+                break
+
+            # Review failed -- re-run development with findings if iterations remain
+            if review_iteration < max_iterations:
+                try:
+                    result = self._run_develop(state)
+                    state.update(result)
+                    state["current_phase"] = "develop_complete"
+                    self._emit_heartbeat("develop", state)
+                except Exception as e:
+                    state["current_phase"] = "error"
+                    state["error"] = f"Development retry stage failed: {e}"
+                    self._emit_heartbeat("develop", state)
+                    return state
+
+                self._validate("develop", state)
+
+        return state
 
     def _run_testing(self, state: Dict[str, Any]) -> Dict[str, Any]:
         from agents.testing_agent import run_testing
@@ -161,67 +235,13 @@ class WorkflowOrchestrator:
         if not self._check_approval("design", "develop"):
             return state
 
-        # -- Stage 2: Development ----------------------------------------------
-        try:
-            result = self._run_develop(state)
-            state.update(result)
-            state["current_phase"] = "develop_complete"
-            self._emit_heartbeat("develop", state)
-        except Exception as e:
-            state["current_phase"] = "error"
-            state["error"] = f"Development stage failed: {e}"
-            self._emit_heartbeat("develop", state)
+        # -- Stage 2: Development (with review gate) ----------------------------
+        # _run_develop_with_review_gate mutates *state* in-place.
+        self._run_develop_with_review_gate(state)
+        if state.get("current_phase") == "error":
             return state
 
-        if not self._validate("develop", state):
-            state["current_phase"] = "error"
-            state["error"] = "Development validation failed"
-            self._emit_heartbeat("develop", state)
-            return state
-
-        if not self._check_approval("develop", "code_review"):
-            return state
-
-        # -- Stage 2.5: Code Review (with auto-fix loop) -----------------------
-        max_iterations = _get_max_review_iterations()
-        review_iteration = 0
-
-        while review_iteration < max_iterations:
-            review_iteration += 1
-
-            try:
-                result = self._run_code_review(state)
-                state.update(result)
-                state["current_phase"] = "review_complete"
-                self._emit_heartbeat("code_review", state)
-            except Exception as e:
-                state["current_phase"] = "error"
-                state["error"] = f"Code review stage failed: {e}"
-                self._emit_heartbeat("code_review", state)
-                return state
-
-            self._validate("code_review", state)
-
-            review_passed = state.get("review_passed", True)
-            if review_passed:
-                break
-
-            # Review failed -- re-run development with findings if iterations remain
-            if review_iteration < max_iterations:
-                try:
-                    result = self._run_develop(state)
-                    state.update(result)
-                    state["current_phase"] = "develop_complete"
-                    self._emit_heartbeat("develop", state)
-                except Exception as e:
-                    state["current_phase"] = "error"
-                    state["error"] = f"Development retry stage failed: {e}"
-                    self._emit_heartbeat("develop", state)
-                    return state
-
-                self._validate("develop", state)
-
-        if not self._check_approval("code_review", "testing"):
+        if not self._check_approval("develop", "testing"):
             return state
 
         # -- Stage 3: Testing --------------------------------------------------

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,0 +1,89 @@
+"""Tests for orchestrator.gates quality gate functions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from orchestrator.gates import run_review_gate
+
+
+class TestRunReviewGate:
+    """run_review_gate delegates to run_code_review."""
+
+    @patch("agents.code_review_agent.run_code_review")
+    def test_delegates_to_run_code_review(self, mock_review: MagicMock) -> None:
+        mock_review.return_value = {
+            "review_passed": True,
+            "review_findings": [],
+            "review_summary": "All good",
+            "review_iteration": 1,
+        }
+
+        state = {
+            "code_files": [{"path": "main.go", "content": "package main"}],
+            "design_analysis": "Some analysis",
+            "acceptance_criteria": ["ac-1"],
+            "session_id": "test",
+        }
+
+        result = run_review_gate(state)
+
+        mock_review.assert_called_once_with(state)
+        assert result["review_passed"] is True
+        assert result["review_findings"] == []
+        assert result["review_iteration"] == 1
+
+    @patch("agents.code_review_agent.run_code_review")
+    def test_returns_failure_from_review(self, mock_review: MagicMock) -> None:
+        mock_review.return_value = {
+            "review_passed": False,
+            "review_findings": ["[BLOCKING] Security: SQL injection"],
+            "review_summary": "1 blocking | FAIL",
+            "review_iteration": 1,
+        }
+
+        state = {
+            "code_files": [{"path": "main.go", "content": "package main"}],
+            "session_id": "test",
+        }
+
+        result = run_review_gate(state)
+
+        assert result["review_passed"] is False
+        assert len(result["review_findings"]) == 1
+
+    @patch("agents.code_review_agent.run_code_review")
+    def test_propagates_exception(self, mock_review: MagicMock) -> None:
+        mock_review.side_effect = RuntimeError("API down")
+
+        state = {"code_files": [], "session_id": "test"}
+
+        with pytest.raises(RuntimeError, match="API down"):
+            run_review_gate(state)
+
+    @patch("agents.code_review_agent.run_code_review")
+    def test_passes_full_state_through(self, mock_review: MagicMock) -> None:
+        """Ensure the gate passes the entire state dict, not a subset."""
+        mock_review.return_value = {
+            "review_passed": True,
+            "review_findings": [],
+            "review_summary": "ok",
+            "review_iteration": 1,
+        }
+
+        state = {
+            "code_files": [{"path": "a.go", "content": ""}],
+            "design_analysis": "analysis",
+            "acceptance_criteria": ["ac-1", "ac-2"],
+            "review_iteration": 0,
+            "session_id": "sess-123",
+            "extra_field": "should be forwarded",
+        }
+
+        run_review_gate(state)
+
+        # The exact same dict object should be passed
+        passed_state = mock_review.call_args[0][0]
+        assert passed_state is state

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -88,7 +88,7 @@ def _docs_result() -> dict:
 
 _DESIGN_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_design"
 _DEVELOP_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_develop"
-_REVIEW_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_code_review"
+_REVIEW_GATE_PATCH = "orchestrator.gates.run_review_gate"
 _TESTING_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_testing"
 _DOCS_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_docs"
 _HEARTBEAT_PATCH = "orchestrator.workflow.WorkflowOrchestrator._emit_heartbeat"
@@ -104,20 +104,20 @@ def _run_kwargs() -> dict:
 # ---------------------------------------------------------------------------
 
 class TestSequentialExecution:
-    """Full pipeline runs all stages in order when everything succeeds."""
+    """Full pipeline runs all 4 stages in order when everything succeeds."""
 
     @patch(_HEARTBEAT_PATCH, return_value=True)
     @patch(_VALIDATE_PATCH, return_value=True)
     @patch(_DOCS_PATCH)
     @patch(_TESTING_PATCH)
-    @patch(_REVIEW_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
     @patch(_DEVELOP_PATCH)
     @patch(_DESIGN_PATCH)
     def test_all_stages_run_sequentially(
         self,
         mock_design: MagicMock,
         mock_develop: MagicMock,
-        mock_review: MagicMock,
+        mock_review_gate: MagicMock,
         mock_testing: MagicMock,
         mock_docs: MagicMock,
         mock_validate: MagicMock,
@@ -126,7 +126,7 @@ class TestSequentialExecution:
     ) -> None:
         mock_design.return_value = _design_result()
         mock_develop.return_value = _develop_result()
-        mock_review.return_value = _review_pass_result()
+        mock_review_gate.return_value = _review_pass_result()
         mock_testing.return_value = _testing_result()
         mock_docs.return_value = _docs_result()
 
@@ -136,26 +136,27 @@ class TestSequentialExecution:
         mock_design.assert_called_once()
         # develop called once (no retry needed)
         mock_develop.assert_called_once()
-        mock_review.assert_called_once()
+        # review gate called once (passed first time)
+        mock_review_gate.assert_called_once()
         mock_testing.assert_called_once()
         mock_docs.assert_called_once()
 
 
-class TestReviewAutoFixRetry:
-    """Code review failure triggers develop -> review retry loop."""
+class TestReviewGateRetry:
+    """Review gate failure triggers develop -> review retry loop."""
 
     @patch(_HEARTBEAT_PATCH, return_value=True)
     @patch(_VALIDATE_PATCH, return_value=True)
     @patch(_DOCS_PATCH)
     @patch(_TESTING_PATCH)
-    @patch(_REVIEW_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
     @patch(_DEVELOP_PATCH)
     @patch(_DESIGN_PATCH)
     def test_review_fail_then_pass(
         self,
         mock_design: MagicMock,
         mock_develop: MagicMock,
-        mock_review: MagicMock,
+        mock_review_gate: MagicMock,
         mock_testing: MagicMock,
         mock_docs: MagicMock,
         mock_validate: MagicMock,
@@ -165,7 +166,7 @@ class TestReviewAutoFixRetry:
         mock_design.return_value = _design_result()
         mock_develop.return_value = _develop_result()
         # First review fails, second passes
-        mock_review.side_effect = [_review_fail_result(1), _review_pass_result()]
+        mock_review_gate.side_effect = [_review_fail_result(1), _review_pass_result()]
         mock_testing.return_value = _testing_result()
         mock_docs.return_value = _docs_result()
 
@@ -174,7 +175,7 @@ class TestReviewAutoFixRetry:
         assert state["current_phase"] == "done"
         # develop: 1 initial + 1 retry = 2
         assert mock_develop.call_count == 2
-        assert mock_review.call_count == 2
+        assert mock_review_gate.call_count == 2
 
 
 class TestMaxReviewIterations:
@@ -184,14 +185,14 @@ class TestMaxReviewIterations:
     @patch(_VALIDATE_PATCH, return_value=True)
     @patch(_DOCS_PATCH)
     @patch(_TESTING_PATCH)
-    @patch(_REVIEW_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
     @patch(_DEVELOP_PATCH)
     @patch(_DESIGN_PATCH)
     def test_max_iterations_reached(
         self,
         mock_design: MagicMock,
         mock_develop: MagicMock,
-        mock_review: MagicMock,
+        mock_review_gate: MagicMock,
         mock_testing: MagicMock,
         mock_docs: MagicMock,
         mock_validate: MagicMock,
@@ -201,7 +202,7 @@ class TestMaxReviewIterations:
         mock_design.return_value = _design_result()
         mock_develop.return_value = _develop_result()
         # All reviews fail
-        mock_review.return_value = _review_fail_result()
+        mock_review_gate.return_value = _review_fail_result()
         mock_testing.return_value = _testing_result()
         mock_docs.return_value = _docs_result()
 
@@ -212,8 +213,8 @@ class TestMaxReviewIterations:
         assert state["current_phase"] == "done"
         # develop: 1 initial + 1 retry = 2
         assert mock_develop.call_count == 2
-        # review called twice (max iterations = 2)
-        assert mock_review.call_count == 2
+        # review gate called twice (max iterations = 2)
+        assert mock_review_gate.call_count == 2
         mock_testing.assert_called_once()
 
 
@@ -254,14 +255,14 @@ class TestStageFailure:
     @patch(_HEARTBEAT_PATCH, return_value=True)
     @patch(_VALIDATE_PATCH, return_value=True)
     @patch(_TESTING_PATCH, side_effect=RuntimeError("test crash"))
-    @patch(_REVIEW_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
     @patch(_DEVELOP_PATCH)
     @patch(_DESIGN_PATCH)
     def test_testing_failure_stops_workflow(
         self,
         mock_design: MagicMock,
         mock_develop: MagicMock,
-        mock_review: MagicMock,
+        mock_review_gate: MagicMock,
         mock_testing: MagicMock,
         mock_validate: MagicMock,
         mock_heartbeat: MagicMock,
@@ -269,7 +270,7 @@ class TestStageFailure:
     ) -> None:
         mock_design.return_value = _design_result()
         mock_develop.return_value = _develop_result()
-        mock_review.return_value = _review_pass_result()
+        mock_review_gate.return_value = _review_pass_result()
         state = orchestrator.run(**_run_kwargs())
         assert state["current_phase"] == "error"
         assert "Testing stage failed" in state["error"]
@@ -287,10 +288,6 @@ class TestValidationFailure:
         orchestrator: WorkflowOrchestrator,
     ) -> None:
         mock_design.return_value = _design_result()
-
-        with patch(_VALIDATE_PATCH, side_effect=lambda self, phase, state: phase != "design"):
-            # Re-bind since we need the method mock to work correctly
-            pass
 
         # Simpler approach: patch _validate to return False for design
         with patch.object(orchestrator, "_validate", return_value=False):
@@ -324,14 +321,14 @@ class TestValidationFailure:
     @patch(_HEARTBEAT_PATCH, return_value=True)
     @patch(_DOCS_PATCH)
     @patch(_TESTING_PATCH)
-    @patch(_REVIEW_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
     @patch(_DEVELOP_PATCH)
     @patch(_DESIGN_PATCH)
     def test_testing_validation_failure_stops_workflow(
         self,
         mock_design: MagicMock,
         mock_develop: MagicMock,
-        mock_review: MagicMock,
+        mock_review_gate: MagicMock,
         mock_testing: MagicMock,
         mock_docs: MagicMock,
         mock_heartbeat: MagicMock,
@@ -339,7 +336,7 @@ class TestValidationFailure:
     ) -> None:
         mock_design.return_value = _design_result()
         mock_develop.return_value = _develop_result()
-        mock_review.return_value = _review_pass_result()
+        mock_review_gate.return_value = _review_pass_result()
         mock_testing.return_value = _testing_result()
         mock_docs.return_value = _docs_result()
 
@@ -354,19 +351,19 @@ class TestValidationFailure:
 
 
 class TestHeartbeatEmission:
-    """Heartbeat is emitted after each stage."""
+    """Heartbeat is emitted after each stage and the review gate."""
 
     @patch(_VALIDATE_PATCH, return_value=True)
     @patch(_DOCS_PATCH)
     @patch(_TESTING_PATCH)
-    @patch(_REVIEW_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
     @patch(_DEVELOP_PATCH)
     @patch(_DESIGN_PATCH)
     def test_heartbeat_emitted_for_each_stage(
         self,
         mock_design: MagicMock,
         mock_develop: MagicMock,
-        mock_review: MagicMock,
+        mock_review_gate: MagicMock,
         mock_testing: MagicMock,
         mock_docs: MagicMock,
         mock_validate: MagicMock,
@@ -374,7 +371,7 @@ class TestHeartbeatEmission:
     ) -> None:
         mock_design.return_value = _design_result()
         mock_develop.return_value = _develop_result()
-        mock_review.return_value = _review_pass_result()
+        mock_review_gate.return_value = _review_pass_result()
         mock_testing.return_value = _testing_result()
         mock_docs.return_value = _docs_result()
 
@@ -388,7 +385,8 @@ class TestHeartbeatEmission:
         assert "orchestrator" in agents_called
         assert "design" in agents_called
         assert "develop" in agents_called
-        assert "code_review" in agents_called
+        # Review is now a gate, not a standalone stage
+        assert "review_gate" in agents_called
         assert "testing" in agents_called
         assert "docs" in agents_called
 
@@ -410,19 +408,19 @@ class TestHeartbeatEmission:
         assert "design" in agents_called
 
 
-class TestCodeReviewRetryDevelopFailure:
-    """Development retry failure during code review loop stops workflow."""
+class TestReviewGateRetryDevelopFailure:
+    """Development retry failure during review gate loop stops workflow."""
 
     @patch(_HEARTBEAT_PATCH, return_value=True)
     @patch(_VALIDATE_PATCH, return_value=True)
-    @patch(_REVIEW_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
     @patch(_DEVELOP_PATCH)
     @patch(_DESIGN_PATCH)
     def test_develop_retry_failure_stops_workflow(
         self,
         mock_design: MagicMock,
         mock_develop: MagicMock,
-        mock_review: MagicMock,
+        mock_review_gate: MagicMock,
         mock_validate: MagicMock,
         mock_heartbeat: MagicMock,
         orchestrator: WorkflowOrchestrator,
@@ -430,10 +428,36 @@ class TestCodeReviewRetryDevelopFailure:
         mock_design.return_value = _design_result()
         # First develop succeeds, retry fails
         mock_develop.side_effect = [_develop_result(), RuntimeError("retry crash")]
-        mock_review.return_value = _review_fail_result()
+        mock_review_gate.return_value = _review_fail_result()
 
         with patch.dict("os.environ", {"MAX_REVIEW_ITERATIONS": "2"}):
             state = orchestrator.run(**_run_kwargs())
 
         assert state["current_phase"] == "error"
         assert "Development retry stage failed" in state["error"]
+
+
+class TestReviewGateFailure:
+    """Review gate exception stops the workflow."""
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    @patch(_VALIDATE_PATCH, return_value=True)
+    @patch(_REVIEW_GATE_PATCH, side_effect=RuntimeError("gate crash"))
+    @patch(_DEVELOP_PATCH)
+    @patch(_DESIGN_PATCH)
+    def test_review_gate_exception_stops_workflow(
+        self,
+        mock_design: MagicMock,
+        mock_develop: MagicMock,
+        mock_review_gate: MagicMock,
+        mock_validate: MagicMock,
+        mock_heartbeat: MagicMock,
+        orchestrator: WorkflowOrchestrator,
+    ) -> None:
+        mock_design.return_value = _design_result()
+        mock_develop.return_value = _develop_result()
+
+        state = orchestrator.run(**_run_kwargs())
+
+        assert state["current_phase"] == "error"
+        assert "Review gate failed" in state["error"]


### PR DESCRIPTION
## Summary
- Create `orchestrator/gates.py` with `run_review_gate()` wrapping existing code review logic
- Update `orchestrator/workflow.py`: 5 stages → 4 (Design → Develop+review gate → Test → Docs)
- Review gate runs after develop with auto-fix retry loop preserved
- Deprecate `agents/code_review_agent.py` (kept as gate implementation)
- 4 new gate tests, workflow tests updated for 4-stage pipeline

Closes #110

## Files Changed
- `orchestrator/gates.py` — NEW: review gate function
- `orchestrator/workflow.py` — Updated: 4 stages, `_run_develop_with_review_gate()`
- `agents/code_review_agent.py` — Deprecation notice added
- `tests/test_gates.py` — NEW: 4 tests
- `tests/test_workflow.py` — Updated for 4-stage pipeline

## Test plan
- [ ] `uv run pytest tests/test_workflow.py tests/test_gates.py -v` — all pass
- [ ] `uv run pytest tests/ -v` — no regressions
- [ ] Verify auto-fix retry loop still works