### PR TITLE
refactor: implement quality gates with repo.yaml commands (#111)

### DIFF
--- a/orchestrator/gates.py
+++ b/orchestrator/gates.py
@@ -3,16 +3,43 @@
 Gates run between stages to enforce quality standards. Unlike stages,
 gates don't produce new artifacts --- they validate existing outputs
 and return pass/fail decisions.
+
+Two kinds of gates:
+
+1. **Review gate** --- delegates to the code-review agent.
+2. **Command gates** --- run shell commands (build / lint / test) defined
+   in ``repos.yaml`` via :class:`config.repo_schema.RepoCommands`.
 """
 
 from __future__ import annotations
 
+import subprocess
+from dataclasses import dataclass
 from typing import Any
 
 from utils.file_logger import get_logger
 
 logger = get_logger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GateResult:
+    """Result of running a single command-based quality gate."""
+
+    gate_name: str
+    passed: bool
+    output: str = ""
+    error: str = ""
+    command: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Review gate (unchanged)
+# ---------------------------------------------------------------------------
 
 def run_review_gate(state: dict[str, Any]) -> dict[str, Any]:
     """Run code review as a quality gate after the Develop stage.
@@ -28,3 +55,119 @@ def run_review_gate(state: dict[str, Any]) -> dict[str, Any]:
     from agents.code_review_agent import run_code_review
 
     return run_code_review(state)
+
+
+# ---------------------------------------------------------------------------
+# Command-based quality gates
+# ---------------------------------------------------------------------------
+
+_COMMAND_TIMEOUT_SECONDS = 300
+
+
+def run_command_gate(
+    command: str,
+    gate_name: str,
+    cwd: str | None = None,
+) -> GateResult:
+    """Run a shell command as a quality gate.
+
+    Args:
+        command: Shell command to execute (e.g. ``go build ./...``).
+        gate_name: Human-readable gate name (e.g. ``"build"``, ``"lint"``).
+        cwd: Working directory for the command.
+
+    Returns:
+        :class:`GateResult` with pass/fail status and captured output.
+    """
+    logger.info("Running %s gate: %s", gate_name, command)
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=_COMMAND_TIMEOUT_SECONDS,
+            cwd=cwd,
+        )
+        passed = result.returncode == 0
+        return GateResult(
+            gate_name=gate_name,
+            passed=passed,
+            output=result.stdout,
+            error=result.stderr,
+            command=command,
+        )
+    except subprocess.TimeoutExpired:
+        return GateResult(
+            gate_name=gate_name,
+            passed=False,
+            error=f"Command timed out after {_COMMAND_TIMEOUT_SECONDS} seconds",
+            command=command,
+        )
+    except Exception as exc:
+        return GateResult(
+            gate_name=gate_name,
+            passed=False,
+            error=str(exc),
+            command=command,
+        )
+
+
+def run_post_develop_gates(
+    repo_path: str | None,
+    commands: dict[str, str] | None = None,
+) -> list[GateResult]:
+    """Run quality gates after the Develop stage.
+
+    Executes ``build`` and ``lint`` commands from ``repos.yaml`` when
+    configured.
+
+    Args:
+        repo_path: Working directory for the commands.
+        commands: Dict with optional ``"build"`` and ``"lint"`` command strings.
+
+    Returns:
+        List of :class:`GateResult` instances (may be empty).
+    """
+    results: list[GateResult] = []
+    if not commands:
+        return results
+
+    for gate_name in ("build", "lint"):
+        cmd = commands.get(gate_name)
+        if cmd:
+            result = run_command_gate(cmd, gate_name, cwd=repo_path)
+            results.append(result)
+            if not result.passed:
+                logger.warning("%s gate failed: %s", gate_name, result.error)
+
+    return results
+
+
+def run_post_test_gates(
+    repo_path: str | None,
+    commands: dict[str, str] | None = None,
+) -> list[GateResult]:
+    """Run quality gates after the Testing stage.
+
+    Executes the ``test`` command from ``repos.yaml`` when configured.
+
+    Args:
+        repo_path: Working directory for the commands.
+        commands: Dict with an optional ``"test"`` command string.
+
+    Returns:
+        List of :class:`GateResult` instances (may be empty).
+    """
+    results: list[GateResult] = []
+    if not commands:
+        return results
+
+    cmd = commands.get("test")
+    if cmd:
+        result = run_command_gate(cmd, "test", cwd=repo_path)
+        results.append(result)
+        if not result.passed:
+            logger.warning("test gate failed: %s", result.error)
+
+    return results

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -63,6 +63,29 @@ class WorkflowOrchestrator:
         self.repo_path = repo_path
         self.output_dir = output_dir
         self._manual_approval = os.getenv("MANUAL_APPROVAL", "false").lower() == "true"
+        self._repo_commands = self._load_repo_commands()
+
+    def _load_repo_commands(self) -> Optional[Dict[str, str]]:
+        """Load commands from repos.yaml for the configured repo_path."""
+        if not self.repo_path:
+            return None
+        try:
+            from config.repo_config import load_repo_config
+
+            project_root = Path(__file__).resolve().parent.parent
+            yaml_path = project_root / "repos.yaml"
+            if not yaml_path.exists():
+                return None
+
+            config = load_repo_config(yaml_path)
+            for repo in config.repos:
+                if repo.path == self.repo_path:
+                    return repo.commands.model_dump(exclude_none=True)
+            return None
+        except Exception as e:
+            from utils.file_logger import get_logger
+            get_logger(__name__).warning("Failed to load repo commands: %s", e)
+            return None
 
     # -- internal helpers -----------------------------------------------------
 
@@ -107,7 +130,8 @@ class WorkflowOrchestrator:
         1. Run development stage
         2. Run review gate
         3. If review fails and iterations remain, re-run develop with findings
-        4. Return combined state updates
+        4. After review passes, run post-develop command gates (build/lint)
+        5. Return combined state updates
 
         Args:
             state: Current workflow state (mutated in-place).
@@ -116,7 +140,7 @@ class WorkflowOrchestrator:
             The mutated *state* dict.  On error ``state["current_phase"]``
             is set to ``"error"``.
         """
-        from orchestrator.gates import run_review_gate
+        from orchestrator.gates import run_post_develop_gates, run_review_gate
 
         # --- initial development run ---
         try:
@@ -173,6 +197,13 @@ class WorkflowOrchestrator:
                     return state
 
                 self._validate("develop", state)
+
+        # --- post-develop command gates (build / lint) ---
+        gate_results = run_post_develop_gates(self.repo_path, self._repo_commands)
+        state["develop_gate_results"] = [
+            {"gate": g.gate_name, "passed": g.passed, "output": g.output, "error": g.error}
+            for g in gate_results
+        ]
 
         return state
 
@@ -261,6 +292,15 @@ class WorkflowOrchestrator:
             state["error"] = "Testing validation failed"
             self._emit_heartbeat("testing", state)
             return state
+
+        # -- Post-test command gates (test) ------------------------------------
+        from orchestrator.gates import run_post_test_gates
+
+        test_gate_results = run_post_test_gates(self.repo_path, self._repo_commands)
+        state["test_gate_results"] = [
+            {"gate": g.gate_name, "passed": g.passed, "output": g.output, "error": g.error}
+            for g in test_gate_results
+        ]
 
         if not self._check_approval("testing", "docs"):
             return state

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from orchestrator.gates import run_review_gate
+from orchestrator.gates import (
+    GateResult,
+    run_command_gate,
+    run_post_develop_gates,
+    run_post_test_gates,
+    run_review_gate,
+)
 
 
 class TestRunReviewGate:
@@ -87,3 +93,171 @@ class TestRunReviewGate:
         # The exact same dict object should be passed
         passed_state = mock_review.call_args[0][0]
         assert passed_state is state
+
+
+# ---------------------------------------------------------------------------
+# GateResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestGateResult:
+    """GateResult stores gate execution metadata."""
+
+    def test_defaults(self) -> None:
+        result = GateResult(gate_name="build", passed=True)
+        assert result.gate_name == "build"
+        assert result.passed is True
+        assert result.output == ""
+        assert result.error == ""
+        assert result.command == ""
+
+    def test_with_all_fields(self) -> None:
+        result = GateResult(
+            gate_name="lint",
+            passed=False,
+            output="stdout text",
+            error="stderr text",
+            command="golangci-lint run",
+        )
+        assert result.gate_name == "lint"
+        assert result.passed is False
+        assert result.output == "stdout text"
+        assert result.error == "stderr text"
+        assert result.command == "golangci-lint run"
+
+
+# ---------------------------------------------------------------------------
+# run_command_gate
+# ---------------------------------------------------------------------------
+
+
+class TestRunCommandGate:
+    """run_command_gate executes a shell command and returns GateResult."""
+
+    def test_successful_command(self) -> None:
+        result = run_command_gate("echo hello", "test_gate")
+        assert result.passed is True
+        assert "hello" in result.output
+        assert result.gate_name == "test_gate"
+        assert result.command == "echo hello"
+
+    def test_failing_command(self) -> None:
+        result = run_command_gate("exit 1", "test_gate")
+        assert result.passed is False
+        assert result.gate_name == "test_gate"
+
+    def test_command_with_cwd(self, tmp_path) -> None:
+        result = run_command_gate("pwd", "test_gate", cwd=str(tmp_path))
+        assert result.passed is True
+        assert str(tmp_path) in result.output
+
+    def test_command_captures_stderr(self) -> None:
+        result = run_command_gate("echo err >&2 && exit 1", "test_gate")
+        assert result.passed is False
+        assert "err" in result.error
+
+    def test_command_timeout(self) -> None:
+        with patch("orchestrator.gates._COMMAND_TIMEOUT_SECONDS", 0):
+            # subprocess.run with timeout=0 should raise TimeoutExpired
+            # for any non-trivial command
+            with patch("subprocess.run", side_effect=__import__("subprocess").TimeoutExpired("cmd", 0)):
+                result = run_command_gate("sleep 999", "test_gate")
+                assert result.passed is False
+                assert "timed out" in result.error
+
+    def test_command_unexpected_exception(self) -> None:
+        with patch("subprocess.run", side_effect=OSError("no such file")):
+            result = run_command_gate("nonexistent", "test_gate")
+            assert result.passed is False
+            assert "no such file" in result.error
+
+    def test_command_with_no_output(self) -> None:
+        result = run_command_gate("true", "test_gate")
+        assert result.passed is True
+        assert result.output == ""
+
+
+# ---------------------------------------------------------------------------
+# run_post_develop_gates
+# ---------------------------------------------------------------------------
+
+
+class TestRunPostDevelopGates:
+    """run_post_develop_gates runs build and lint commands."""
+
+    def test_with_both_commands(self) -> None:
+        commands = {"build": "echo build_ok", "lint": "echo lint_ok"}
+        results = run_post_develop_gates("/tmp", commands)
+        assert len(results) == 2
+        assert all(r.passed for r in results)
+        assert results[0].gate_name == "build"
+        assert results[1].gate_name == "lint"
+
+    def test_with_no_commands(self) -> None:
+        results = run_post_develop_gates("/tmp", None)
+        assert results == []
+
+    def test_with_empty_dict(self) -> None:
+        results = run_post_develop_gates("/tmp", {})
+        assert results == []
+
+    def test_build_fails_lint_still_runs(self) -> None:
+        commands = {"build": "exit 1", "lint": "echo ok"}
+        results = run_post_develop_gates("/tmp", commands)
+        assert len(results) == 2
+        assert not results[0].passed  # build failed
+        assert results[1].passed  # lint passed
+
+    def test_only_build_configured(self) -> None:
+        commands = {"build": "echo build_ok"}
+        results = run_post_develop_gates("/tmp", commands)
+        assert len(results) == 1
+        assert results[0].gate_name == "build"
+        assert results[0].passed is True
+
+    def test_only_lint_configured(self) -> None:
+        commands = {"lint": "echo lint_ok"}
+        results = run_post_develop_gates("/tmp", commands)
+        assert len(results) == 1
+        assert results[0].gate_name == "lint"
+        assert results[0].passed is True
+
+    def test_ignores_unrelated_commands(self) -> None:
+        commands = {"test": "echo ignored", "doc": "echo also_ignored"}
+        results = run_post_develop_gates("/tmp", commands)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# run_post_test_gates
+# ---------------------------------------------------------------------------
+
+
+class TestRunPostTestGates:
+    """run_post_test_gates runs the test command."""
+
+    def test_with_test_command(self) -> None:
+        commands = {"test": "echo tests_pass"}
+        results = run_post_test_gates("/tmp", commands)
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert results[0].gate_name == "test"
+
+    def test_with_no_commands(self) -> None:
+        results = run_post_test_gates("/tmp", None)
+        assert results == []
+
+    def test_with_empty_dict(self) -> None:
+        results = run_post_test_gates("/tmp", {})
+        assert results == []
+
+    def test_test_command_fails(self) -> None:
+        commands = {"test": "exit 1"}
+        results = run_post_test_gates("/tmp", commands)
+        assert len(results) == 1
+        assert not results[0].passed
+
+    def test_ignores_build_and_lint(self) -> None:
+        commands = {"build": "echo ignored", "lint": "echo ignored"}
+        results = run_post_test_gates("/tmp", commands)
+        assert results == []


### PR DESCRIPTION
## Summary
- Add `GateResult` dataclass for structured gate results in `orchestrator/gates.py`
- Add `run_command_gate()` for executing repo.yaml build/lint/test commands as quality gates
- Add `run_post_develop_gates()` (build + lint) and `run_post_test_gates()` (test commands) orchestration helpers
- Integrate quality gates into `WorkflowOrchestrator` after develop and testing stages (non-blocking, stores results in state)
- Extend `tests/test_gates.py` from 4 to 25 tests covering all new gate functionality

## Test plan
- [x] 25 tests in test_gates.py pass
- [x] GateResult dataclass stores gate_name, passed, output, error, command
- [x] run_command_gate handles success, failure, timeout, and missing commands
- [x] Post-develop gates run build and lint commands from repo.yaml
- [x] Post-test gates run test commands from repo.yaml

Closes #111