### PR TITLE
feat: implement pause/resume signal handling (#128)

### DIFF
--- a/dashboard/backend.py
+++ b/dashboard/backend.py
@@ -862,6 +862,18 @@ async def pause_session(session_id: str):
     return {"status": "ok"}
 
 
+@app.post("/api/sessions/{session_id}/resume")
+async def resume_session(session_id: str):
+    """Resume a paused pipeline by removing its pause signal."""
+    _validate_session_id(session_id)
+    pause_file = SIGNAL_DIR / f"pause-{session_id}"
+    existed = pause_file.exists()
+    pause_file.unlink(missing_ok=True)
+    if existed:
+        logger.info(f"Resume signal sent: session={session_id}")
+    return {"status": "ok"}
+
+
 @app.patch("/api/sessions/{session_id}/archive")
 async def archive_session(session_id: str):
     """Archive a session — hides it from the dashboard but preserves all data and artifacts."""

--- a/dashboard/frontend/src/api/client.js
+++ b/dashboard/frontend/src/api/client.js
@@ -36,6 +36,12 @@ export async function pauseSession(sessionId) {
   return res.json()
 }
 
+export async function resumeSession(sessionId) {
+  const res = await fetch(`${BASE}/api/sessions/${sessionId}/resume`, { method: 'POST' })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+
 export async function archiveSession(sessionId) {
   const res = await fetch(`${BASE}/api/sessions/${sessionId}/archive`, { method: 'PATCH' })
   if (!res.ok) throw new Error(await res.text())

--- a/dashboard/frontend/src/pages/Dashboard.jsx
+++ b/dashboard/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { getSessions, approveSession, pauseSession, archiveSession, deleteSession, cleanStuckSessions } from '../api/client'
+import { getSessions, approveSession, pauseSession, resumeSession, archiveSession, deleteSession, cleanStuckSessions } from '../api/client'
 import StatusBadge from '../components/StatusBadge'
 
 const PHASE_LABELS = {
@@ -11,6 +11,7 @@ const PHASE_LABELS = {
   testing_complete: { label: 'Tests ✓',     color: 'bg-teal-100 text-teal-700' },
   done:             { label: 'Done ✓',      color: 'bg-green-100 text-green-700' },
   error:            { label: 'Error',       color: 'bg-red-100 text-red-600' },
+  paused:           { label: 'Paused',     color: 'bg-yellow-100 text-yellow-700' },
 }
 
 function PhaseChip({ phase }) {
@@ -174,10 +175,16 @@ export default function Dashboard() {
                             Approve
                           </button>
                         )}
-                        {status === 'running' && (
+                        {status === 'running' && session.latest_heartbeat?.phase !== 'paused' && (
                           <button className="px-2 py-1 text-xs border border-gray-300 text-gray-600 rounded hover:bg-gray-50"
                             onClick={() => pauseSession(session.id).then(load)}>
                             Pause
+                          </button>
+                        )}
+                        {status === 'running' && session.latest_heartbeat?.phase === 'paused' && (
+                          <button className="px-2 py-1 text-xs border border-gray-300 text-gray-600 rounded hover:bg-gray-50"
+                            onClick={() => resumeSession(session.id).then(load)}>
+                            Resume
                           </button>
                         )}
                         {(status === 'completed' || status === 'failed') && (

--- a/dashboard/frontend/src/pages/RunDetails.jsx
+++ b/dashboard/frontend/src/pages/RunDetails.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { getSession, approveSession, pauseSession, streamLogs, deleteSession } from '../api/client'
+import { getSession, approveSession, pauseSession, resumeSession, streamLogs, deleteSession } from '../api/client'
 import StatusBadge from '../components/StatusBadge'
 import PipelineProgress from '../components/PipelineProgress'
 
@@ -145,10 +145,16 @@ export default function RunDetails() {
               </button>
             </>
           )}
-          {status === 'running' && (
+          {status === 'running' && session?.latest_heartbeat?.phase !== 'paused' && (
             <button onClick={() => pauseSession(sessionId).then(loadSession)}
               className="px-4 py-2 border border-gray-300 text-gray-600 rounded-lg text-sm hover:bg-gray-50">
               Pause
+            </button>
+          )}
+          {status === 'running' && session?.latest_heartbeat?.phase === 'paused' && (
+            <button onClick={() => resumeSession(sessionId).then(loadSession)}
+              className="px-4 py-2 border border-gray-300 text-gray-600 rounded-lg text-sm hover:bg-gray-50">
+              Resume
             </button>
           )}
           {(currentPhase === 'done') && (

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -11,12 +11,17 @@ Develop via :func:`orchestrator.gates.run_review_gate`.
 from __future__ import annotations
 
 import os
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 
 # Maximum code-review retry iterations (develop -> review loop).
 _DEFAULT_MAX_REVIEW_ITERATIONS = 2
+
+_SIGNAL_DIR = Path("/tmp/claude/signals")
+_PAUSE_POLL_INTERVAL = 2  # seconds
+_MAX_PAUSE_SECONDS = int(os.getenv("MAX_PAUSE_SECONDS", "3600"))
 
 
 def _get_max_review_iterations() -> int:
@@ -115,6 +120,33 @@ class WorkflowOrchestrator:
     def _should_run_stage(self, stage: str) -> bool:
         """Check if a stage should run based on repos.yaml configuration."""
         return stage in self._active_stages
+
+    def _check_pause_signal(self, state: Dict[str, Any]) -> None:
+        """Check for pause signal and block until resumed or timeout."""
+        pause_file = _SIGNAL_DIR / f"pause-{self.session_id}"
+        if not pause_file.exists():
+            return
+
+        previous_phase = state.get("current_phase", "init")
+        state["current_phase"] = "paused"
+        state["paused_at_phase"] = previous_phase
+        self._emit_heartbeat("orchestrator", state)
+
+        elapsed = 0
+        while pause_file.exists():
+            if elapsed >= _MAX_PAUSE_SECONDS:
+                state["current_phase"] = "error"
+                state["error"] = f"Pause timeout after {_MAX_PAUSE_SECONDS}s"
+                self._emit_heartbeat("orchestrator", state)
+                pause_file.unlink(missing_ok=True)
+                return
+            time.sleep(_PAUSE_POLL_INTERVAL)
+            elapsed += _PAUSE_POLL_INTERVAL
+
+        # Resumed — restore previous phase
+        state["current_phase"] = previous_phase
+        del state["paused_at_phase"]
+        self._emit_heartbeat("orchestrator", state)
 
     def _check_approval(self, phase: str, next_phase: str) -> bool:
         """Check if approval is needed based on repos.yaml or env var.
@@ -300,6 +332,7 @@ class WorkflowOrchestrator:
                 self._emit_heartbeat("design", state)
                 return state
 
+            self._check_pause_signal(state)
             if not self._check_approval("design", "develop"):
                 return state
         else:
@@ -312,6 +345,7 @@ class WorkflowOrchestrator:
             if state.get("current_phase") == "error":
                 return state
 
+            self._check_pause_signal(state)
             if not self._check_approval("develop", "testing"):
                 return state
         else:
@@ -345,6 +379,7 @@ class WorkflowOrchestrator:
                 for g in test_gate_results
             ]
 
+            self._check_pause_signal(state)
             if not self._check_approval("testing", "docs"):
                 return state
         else:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -794,3 +795,145 @@ class TestRepoConfigLoading:
         approvals = orchestrator._repo_config.approvals
         assert approvals.required_stages == []
         assert approvals.auto_approve is False
+
+
+class TestPauseSignal:
+    """Pause signal file blocks workflow until removed or timeout."""
+
+    @pytest.fixture(autouse=True)
+    def _signal_dir(self, tmp_path: Path) -> None:
+        """Redirect _SIGNAL_DIR to a temp directory and clean up after each test."""
+        self.signal_dir = tmp_path / "signals"
+        self.signal_dir.mkdir()
+
+    @pytest.fixture()
+    def paused_orchestrator(self) -> WorkflowOrchestrator:
+        """Return a WorkflowOrchestrator using the temp signal directory."""
+        orch = WorkflowOrchestrator(
+            session_id="pause-test",
+            repo_path="/tmp/fake-repo",
+        )
+        return orch
+
+    def _pause_file(self) -> Path:
+        return self.signal_dir / "pause-pause-test"
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    def test_no_pause_file_is_noop(
+        self,
+        mock_heartbeat: MagicMock,
+        paused_orchestrator: WorkflowOrchestrator,
+    ) -> None:
+        """When no pause file exists, the method returns immediately without modifying state."""
+        state = {"current_phase": "design_complete", "session_id": "pause-test"}
+        original_state = state.copy()
+
+        with patch("orchestrator.workflow._SIGNAL_DIR", self.signal_dir):
+            paused_orchestrator._check_pause_signal(state)
+
+        assert state == original_state
+        mock_heartbeat.assert_not_called()
+
+    def test_pause_blocks_until_file_removed(
+        self,
+        paused_orchestrator: WorkflowOrchestrator,
+    ) -> None:
+        """Pause file blocks execution; heartbeats show 'paused' phase; previous phase restored."""
+        pause_file = self._pause_file()
+        pause_file.touch()
+        state = {"current_phase": "design_complete", "session_id": "pause-test"}
+
+        # Capture snapshots of state at each heartbeat call (state is mutated in place)
+        heartbeat_snapshots: list[tuple[str, dict]] = []
+
+        def capture_heartbeat(agent: str, st: dict) -> bool:
+            heartbeat_snapshots.append((agent, dict(st)))
+            return True
+
+        def remove_after_delay() -> None:
+            import time
+            time.sleep(0.3)
+            pause_file.unlink()
+
+        remover = threading.Thread(target=remove_after_delay)
+        remover.start()
+
+        with (
+            patch("orchestrator.workflow._SIGNAL_DIR", self.signal_dir),
+            patch("orchestrator.workflow._PAUSE_POLL_INTERVAL", 0.1),
+            patch.object(paused_orchestrator, "_emit_heartbeat", side_effect=capture_heartbeat),
+        ):
+            paused_orchestrator._check_pause_signal(state)
+
+        remover.join()
+
+        # Previous phase should be restored after resume
+        assert state["current_phase"] == "design_complete"
+        assert "paused_at_phase" not in state
+
+        # At least two heartbeats: one for entering paused, one for resuming
+        assert len(heartbeat_snapshots) >= 2
+
+        # First heartbeat should show paused phase
+        first_agent, first_hb_state = heartbeat_snapshots[0]
+        assert first_agent == "orchestrator"
+        assert first_hb_state["current_phase"] == "paused"
+        assert first_hb_state["paused_at_phase"] == "design_complete"
+
+        # Last heartbeat should show restored phase
+        last_agent, last_hb_state = heartbeat_snapshots[-1]
+        assert last_agent == "orchestrator"
+        assert last_hb_state["current_phase"] == "design_complete"
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    def test_pause_preserves_previous_phase(
+        self,
+        mock_heartbeat: MagicMock,
+        paused_orchestrator: WorkflowOrchestrator,
+    ) -> None:
+        """current_phase is restored to the exact value before pause after file removal."""
+        pause_file = self._pause_file()
+        pause_file.touch()
+        state = {"current_phase": "testing_complete", "session_id": "pause-test"}
+
+        def remove_after_delay() -> None:
+            import time
+            time.sleep(0.2)
+            pause_file.unlink()
+
+        remover = threading.Thread(target=remove_after_delay)
+        remover.start()
+
+        with (
+            patch("orchestrator.workflow._SIGNAL_DIR", self.signal_dir),
+            patch("orchestrator.workflow._PAUSE_POLL_INTERVAL", 0.1),
+        ):
+            paused_orchestrator._check_pause_signal(state)
+
+        remover.join()
+
+        assert state["current_phase"] == "testing_complete"
+        assert "paused_at_phase" not in state
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    def test_pause_timeout(
+        self,
+        mock_heartbeat: MagicMock,
+        paused_orchestrator: WorkflowOrchestrator,
+    ) -> None:
+        """When timeout expires, current_phase becomes 'error' and pause file is removed."""
+        pause_file = self._pause_file()
+        pause_file.touch()
+        state = {"current_phase": "develop_complete", "session_id": "pause-test"}
+
+        with (
+            patch("orchestrator.workflow._SIGNAL_DIR", self.signal_dir),
+            patch("orchestrator.workflow._MAX_PAUSE_SECONDS", 2),
+            patch("orchestrator.workflow._PAUSE_POLL_INTERVAL", 0.1),
+        ):
+            paused_orchestrator._check_pause_signal(state)
+
+        assert state["current_phase"] == "error"
+        assert "Pause timeout" in state["error"]
+        # Pause file should be cleaned up on timeout
+        assert not pause_file.exists()


### PR DESCRIPTION
## Summary
- Implement file-based pause/resume signal protocol between dashboard UI and orchestrator
- Orchestrator polls for `/tmp/claude/signals/pause-{session_id}` at stage transitions (design→develop, develop→testing, testing→docs)
- Pause preserves current phase state; resume restores it. Configurable timeout (default 1h) via `MAX_PAUSE_SECONDS` env var
- Added `POST /api/sessions/{id}/resume` backend endpoint with idempotent file removal
- Frontend shows Pause/Resume toggle buttons on Dashboard and RunDetails views, gated on running status

## Files Changed
- `orchestrator/workflow.py` — `_check_pause_signal()` method with polling, timeout, phase preservation
- `dashboard/backend.py` — Resume endpoint
- `dashboard/frontend/src/api/client.js` — `resumeSession()` API client
- `dashboard/frontend/src/pages/Dashboard.jsx` — Pause/Resume UI toggle, 'paused' phase label
- `dashboard/frontend/src/pages/RunDetails.jsx` — Pause/Resume UI toggle
- `tests/test_workflow.py` — 4 new tests (no-op, blocking, phase preservation, timeout)

## Test plan
- [x] 792 tests pass (4 skipped, 2 pre-existing failures unrelated)
- [x] All 4 new pause/resume tests pass
- [ ] Manual test: start a run from dashboard, click Pause, verify orchestrator blocks, click Resume, verify it continues

Closes #128