### PR TITLE
fix(dashboard): persist database across restarts (#130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Tests are in `tests/` and use pytest. The `conftest.py` provides shared fixtures
 | `ENABLE_REPO_ANALYSIS` | Enable/disable repo analysis (default: `true`). Set to `false` to skip repo scanning. |
 | `DASHBOARD_URL` | Dashboard URL (default: `http://localhost:8080`) |
 | `DASHBOARD_ENABLED` | Enable heartbeats (default: `true`) |
-| `DASHBOARD_DB_PATH` | SQLite DB path (default: `/tmp/claude/dashboard.db`) |
+| `DASHBOARD_DB_PATH` | SQLite DB path (default: `~/.local/share/flowpilot/dashboard.db`) |
 | `PII_REDACTION_ENABLED` | Redact PII from Jira/GitHub data at fetch time (default: `true`). Set to `false` for local dev only. |
 | `PROMPT_GUARD_ENABLED` | Sanitize external text for prompt injection patterns before prompt assembly (default: `true`). Set to `false` for local dev only. |
 | `OUTPUT_SANITIZER_ENABLED` | Enable/disable output sanitizer (default: `true`) |

--- a/dashboard/backend.py
+++ b/dashboard/backend.py
@@ -32,7 +32,8 @@ from utils.file_logger import get_logger
 logger = get_logger('dashboard.backend')
 
 # Database path
-DB_PATH = os.getenv("DASHBOARD_DB_PATH", "/tmp/claude/dashboard.db")
+_DEFAULT_DB_PATH = str(Path.home() / ".local" / "share" / "flowpilot" / "dashboard.db")
+DB_PATH = os.path.expanduser(os.getenv("DASHBOARD_DB_PATH", _DEFAULT_DB_PATH))
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ORCHESTRATE_SCRIPT = os.path.join(PROJECT_ROOT, "scripts", "orchestrate.py")


### PR DESCRIPTION
## Summary
- Move default `DASHBOARD_DB_PATH` from `/tmp/claude/dashboard.db` (tmpfs, RAM-backed) to `~/.local/share/flowpilot/dashboard.db` (persistent disk)
- Wrap env var in `os.path.expanduser()` so user-provided paths with `~` are correctly expanded
- Updated CLAUDE.md environment variable docs

## Test plan
- [x] 788 tests pass (no regressions)
- [ ] Manual: restart dashboard, verify runs persist

Closes #130