### PR TITLE
fix(dashboard): pass Jira enrichment data through orchestrator (#131)

### DIFF
--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -258,6 +258,7 @@ class WorkflowOrchestrator:
         title: str,
         description: str,
         issue_type: str = "feature",
+        extra_state: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Execute the full sequential pipeline.
 
@@ -265,6 +266,8 @@ class WorkflowOrchestrator:
             title: Issue / feature title.
             description: Issue / feature description.
             issue_type: One of ``"feature"``, ``"bug"``, ``"refactor"``.
+            extra_state: Optional additional fields to merge into the
+                initial pipeline state (e.g. Jira enrichment data).
 
         Returns:
             Final accumulated state dict.  ``current_phase`` will be
@@ -278,6 +281,12 @@ class WorkflowOrchestrator:
             "repo_path": self.repo_path or "",
             "current_phase": "init",
         }
+
+        if extra_state:
+            _protected = {"session_id", "issue_title", "issue_description",
+                          "issue_type", "repo_path", "current_phase"}
+            state.update({k: v for k, v in extra_state.items()
+                          if k not in _protected})
 
         self._emit_heartbeat("orchestrator", state)
 

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -27,6 +27,13 @@ MANUAL_APPROVAL = os.getenv("MANUAL_APPROVAL", "false").lower() == "true"
 
 from orchestrator.workflow import WorkflowOrchestrator
 
+# Keys that WorkflowOrchestrator.run() sets from its explicit parameters.
+# Excluded from extra_state to avoid duplication.
+_CORE_STATE_KEYS = frozenset({
+    "session_id", "issue_title", "issue_description", "issue_type",
+    "repo_path", "repo_paths", "current_phase",
+})
+
 
 # -- helpers ------------------------------------------------------------------
 
@@ -323,10 +330,13 @@ def orchestrate(
             output_dir=pathlib.Path(output_dir) if output_dir else None,
         )
 
+        extra_state = {k: v for k, v in state.items() if k not in _CORE_STATE_KEYS}
+
         state = orchestrator.run(
             title=title,
             description=description,
             issue_type=issue_type,
+            extra_state=extra_state if extra_state else None,
         )
 
         total_duration = time.time() - pipeline_start


### PR DESCRIPTION
## Summary
- Add `extra_state` parameter to `WorkflowOrchestrator.run()` to accept additional pipeline state fields
- Extract Jira enrichment data (ticket ID, URL, priority, labels, linked issues) in `orchestrate.py` and pass via `extra_state`
- Protected keys (session_id, current_phase, etc.) are filtered out to prevent overwrites
- `_CORE_STATE_KEYS` moved to module-level frozenset for maintainability

## Root Cause
`orchestrator.run()` created a fresh state dict discarding all Jira data fetched in `orchestrate.py`. The `JiraInfoEnricher` never found `jira_ticket_id` in heartbeat data, so the dashboard JIRA column showed "—".

## Test plan
- [x] 788 tests pass (no regressions)
- [ ] Manual: run pipeline with Jira ticket, verify JIRA column shows ticket ID on dashboard

Closes #131