### PR TITLE
fix(tests): resolve 2 pre-existing test failures (#135)

### DIFF
--- a/dashboard/backend.py
+++ b/dashboard/backend.py
@@ -392,7 +392,7 @@ class Database:
         Returns:
             dict with counts of deleted sessions and heartbeats
         """
-        cutoff_time = datetime.now() - timedelta(hours=max_age_hours)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
         cutoff_timestamp = cutoff_time.isoformat()
 
         # Get session IDs to delete
@@ -765,7 +765,7 @@ async def health():
     Returns:
         Health status
     """
-    return {"status": "healthy", "timestamp": datetime.utcnow().isoformat()}
+    return {"status": "healthy", "timestamp": datetime.now(timezone.utc).isoformat()}
 
 
 @app.post("/api/runs")

--- a/tests/test_dashboard_cleanup.py
+++ b/tests/test_dashboard_cleanup.py
@@ -6,7 +6,7 @@ Tests the cleanup endpoints and automatic cleanup task.
 import os
 import json
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 # Set test database path before importing backend
@@ -29,7 +29,7 @@ def setup_test_db() -> Database:
 def insert_test_session(db: Database, session_id: str, phase: str, hours_ago: int = 0):
     """Insert a test session with heartbeat."""
     # Calculate timestamp
-    timestamp = datetime.now() - timedelta(hours=hours_ago)
+    timestamp = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
     timestamp_str = timestamp.isoformat()
 
     # Prepare test data

--- a/tests/test_file_logger.py
+++ b/tests/test_file_logger.py
@@ -28,9 +28,16 @@ def cleanup_loggers():
 class TestGetLogger:
     """Test the get_logger function."""
 
-    def test_logger_creation_with_defaults(self):
+    def test_logger_creation_with_defaults(self, monkeypatch):
         """Test creating a logger with default settings."""
-        logger = get_logger('test_agent')
+        monkeypatch.delenv('LOG_LEVEL', raising=False)
+
+        import importlib
+        import utils.file_logger as _fl_mod
+        importlib.reload(_fl_mod)
+        _get_logger = _fl_mod.get_logger
+
+        logger = _get_logger('test_agent')
 
         assert logger.name == 'test_agent'
         assert logger.level == logging.INFO

--- a/utils/file_logger.py
+++ b/utils/file_logger.py
@@ -45,13 +45,12 @@ def get_logger(
          logger.info("Starting design analysis")
     """
     logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.propagate = False
 
     # Avoid adding duplicate handlers
     if logger.handlers:
         return logger
-
-    logger.setLevel(level)
-    logger.propagate = False
 
     # Create formatter
     formatter = logging.Formatter(


### PR DESCRIPTION
## Summary
- Fix `test_cleanup_stuck_sessions`: timezone mismatch — test used naive `datetime.now()` but cleanup code uses `datetime.now(timezone.utc)`. Also fixed `cleanup_old_sessions` and health endpoint to use UTC-aware datetimes consistently.
- Fix `test_logger_creation_with_defaults`: test now isolates from `LOG_LEVEL` env var (set to DEBUG in `.env`) by patching the environment and reloading the module. Also moved `setLevel`/`propagate` before the early-return handler check in `get_logger()`.

## Results
- Before: 792 passed, 2 failed
- After: **794 passed, 0 failed**, 4 skipped

## Test plan
- [x] Full pytest suite: 794 passed, 0 failed, 4 skipped

Closes #135