### PR TITLE
fix(dashboard): use correct phase field for pause/resume toggle (#137)

### DIFF
--- a/dashboard/frontend/src/pages/Dashboard.jsx
+++ b/dashboard/frontend/src/pages/Dashboard.jsx
@@ -24,12 +24,11 @@ function PhaseChip({ phase }) {
 }
 
 function deriveStatus(session) {
-  const phase = session.latest_heartbeat?.phase || session.status || 'init'
-  const currentPhase = session.latest_heartbeat?.raw_state?.current_phase
-  if (phase === 'done' || currentPhase === 'done') return 'completed'
-  if (phase === 'error' || currentPhase === 'error') return 'failed'
-  if (phase?.includes('waiting') || currentPhase?.includes('waiting')) return 'waiting'
-  if (phase === 'init' && !currentPhase) return 'init'
+  const phase = session.latest_heartbeat?.raw_state?.current_phase || session.status || 'init'
+  if (phase === 'done') return 'completed'
+  if (phase === 'error') return 'failed'
+  if (phase.includes('waiting')) return 'waiting'
+  if (phase === 'init') return 'init'
   return 'running'
 }
 
@@ -175,13 +174,13 @@ export default function Dashboard() {
                             Approve
                           </button>
                         )}
-                        {status === 'running' && session.latest_heartbeat?.phase !== 'paused' && (
+                        {status === 'running' && session.latest_heartbeat?.raw_state?.current_phase !== 'paused' && (
                           <button className="px-2 py-1 text-xs border border-gray-300 text-gray-600 rounded hover:bg-gray-50"
                             onClick={() => pauseSession(session.id).then(load)}>
                             Pause
                           </button>
                         )}
-                        {status === 'running' && session.latest_heartbeat?.phase === 'paused' && (
+                        {status === 'running' && session.latest_heartbeat?.raw_state?.current_phase === 'paused' && (
                           <button className="px-2 py-1 text-xs border border-gray-300 text-gray-600 rounded hover:bg-gray-50"
                             onClick={() => resumeSession(session.id).then(load)}>
                             Resume

--- a/dashboard/frontend/src/pages/RunDetails.jsx
+++ b/dashboard/frontend/src/pages/RunDetails.jsx
@@ -5,12 +5,11 @@ import StatusBadge from '../components/StatusBadge'
 import PipelineProgress from '../components/PipelineProgress'
 
 function deriveStatus(session) {
-  const phase = session?.latest_heartbeat?.phase || 'init'
-  const currentPhase = session?.latest_heartbeat?.raw_state?.current_phase
-  if (phase === 'done' || currentPhase === 'done') return 'completed'
-  if (phase === 'error' || currentPhase === 'error') return 'failed'
-  if (phase?.includes('waiting') || currentPhase?.includes('waiting')) return 'waiting'
-  if (phase === 'init' && !currentPhase) return 'init'
+  const phase = session?.latest_heartbeat?.raw_state?.current_phase || session?.status || 'init'
+  if (phase === 'done') return 'completed'
+  if (phase === 'error') return 'failed'
+  if (phase.includes('waiting')) return 'waiting'
+  if (phase === 'init') return 'init'
   return 'running'
 }
 
@@ -145,13 +144,13 @@ export default function RunDetails() {
               </button>
             </>
           )}
-          {status === 'running' && session?.latest_heartbeat?.phase !== 'paused' && (
+          {status === 'running' && session?.latest_heartbeat?.raw_state?.current_phase !== 'paused' && (
             <button onClick={() => pauseSession(sessionId).then(loadSession)}
               className="px-4 py-2 border border-gray-300 text-gray-600 rounded-lg text-sm hover:bg-gray-50">
               Pause
             </button>
           )}
-          {status === 'running' && session?.latest_heartbeat?.phase === 'paused' && (
+          {status === 'running' && session?.latest_heartbeat?.raw_state?.current_phase === 'paused' && (
             <button onClick={() => resumeSession(sessionId).then(loadSession)}
               className="px-4 py-2 border border-gray-300 text-gray-600 rounded-lg text-sm hover:bg-gray-50">
               Resume


### PR DESCRIPTION
## Summary
- Fix Pause/Resume button toggle to read `raw_state.current_phase` instead of `.phase` (which is the agent name, not the pipeline phase)
- Fix `deriveStatus()` in both Dashboard.jsx and RunDetails.jsx to use the same correct field
- Simplify by removing redundant `currentPhase` variable

## Root Cause
`.phase` on the heartbeat is the agent name (e.g., "orchestrator"), not the pipeline lifecycle phase. The actual phase ("paused", "done", "error") lives at `.raw_state.current_phase`.

## Test plan
- [ ] Trigger a pipeline run, click Pause, verify Resume button appears
- [ ] Click Resume, verify pipeline continues and Pause button returns

Closes #137