### PR TITLE
feat(pipeline): support multiple repos from repos.yaml (#139)

### DIFF
--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 
 # Maximum code-review retry iterations (develop -> review loop).
@@ -62,10 +62,12 @@ class WorkflowOrchestrator:
         self,
         session_id: str,
         repo_path: Optional[str] = None,
+        repo_paths: Optional[List[str]] = None,
         output_dir: Optional[Path] = None,
     ) -> None:
         self.session_id = session_id
-        self.repo_path = repo_path
+        self.repo_paths = repo_paths or ([repo_path] if repo_path else [])
+        self.repo_path = repo_path or (self.repo_paths[0] if self.repo_paths else None)
         self.output_dir = output_dir
         self._manual_approval = os.getenv("MANUAL_APPROVAL", "false").lower() == "true"
         self._repo_config = self._load_repo_config()
@@ -185,11 +187,16 @@ class WorkflowOrchestrator:
             title=state["issue_title"],
             description=state["issue_description"],
             repo_path=state.get("repo_path"),
+            repo_paths=state.get("repo_paths", []),
         )
 
     def _run_develop(self, state: Dict[str, Any]) -> Dict[str, Any]:
         from stages.develop import run_development
-        return run_development(state, repo_path=state.get("repo_path"))
+        return run_development(
+            state,
+            repo_path=state.get("repo_path"),
+            repo_paths=state.get("repo_paths", []),
+        )
 
     def _run_develop_with_review_gate(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """Run development followed by the review quality gate.
@@ -310,7 +317,8 @@ class WorkflowOrchestrator:
             "issue_title": title,
             "issue_description": description,
             "issue_type": issue_type,
-            "repo_path": self.repo_path or "",
+            "repo_path": self.repo_paths[0] if self.repo_paths else "",
+            "repo_paths": self.repo_paths,
             "current_phase": "init",
         }
 

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -327,6 +327,7 @@ def orchestrate(
         orchestrator = WorkflowOrchestrator(
             session_id=session_id,
             repo_path=repo_path,
+            repo_paths=repo_paths,
             output_dir=pathlib.Path(output_dir) if output_dir else None,
         )
 

--- a/stages/design.py
+++ b/stages/design.py
@@ -10,7 +10,7 @@ implementation planning.
 
 import os
 import re
-from typing import Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
 from prompts.design import DESIGN_AGENT_PROMPT
 from config.auth_config import get_anthropic_client
@@ -34,7 +34,12 @@ class DesignAgentError(Exception):
     """Base exception for Design Agent errors."""
 
 
-def run_design(title: str, description: str, repo_path: Optional[str] = None) -> Dict[str, Any]:
+def run_design(
+    title: str,
+    description: str,
+    repo_path: Optional[str] = None,
+    repo_paths: Optional[List[str]] = None,
+) -> Dict[str, Any]:
     """Run design analysis on a GitHub issue.
 
     This function analyzes a feature request or bug report and produces a comprehensive
@@ -46,6 +51,8 @@ def run_design(title: str, description: str, repo_path: Optional[str] = None) ->
         description: GitHub issue description/body
         repo_path: Optional path to the Shipwright repository for code analysis.
                   If not provided, analysis is based on component metadata only.
+        repo_paths: Optional list of repository paths to gather context from.
+                   When provided, takes precedence over repo_path.
 
     Returns:
         Dictionary containing:
@@ -76,12 +83,13 @@ def run_design(title: str, description: str, repo_path: Optional[str] = None) ->
         logger.error(f"Failed to initialize Claude client: {e}", exc_info=True)
         raise DesignAgentError(f"Failed to initialize Claude client: {e}") from e
 
-    # Gather repository context if path provided
-    if repo_path:
-        logger.info(f"Gathering repository context from: {repo_path}")
-        repo_context = _gather_repo_context(repo_path)
+    # Resolve effective repo list: prefer repo_paths, fall back to repo_path
+    effective_paths = repo_paths or ([repo_path] if repo_path else [])
+
+    if effective_paths:
+        repo_context = _gather_multi_repo_context(effective_paths)
     else:
-        logger.info("No repository path provided, skipping repository context")
+        logger.info("No repository paths provided, skipping repository context")
         repo_context = None
 
     # Build component information context
@@ -271,6 +279,40 @@ def _gather_repo_context(repo_path: str) -> Dict[str, Any]:
         context["error"] = f"Repository analysis failed: {str(e)}"
 
     return context
+
+
+def _gather_multi_repo_context(repo_paths: List[str]) -> Optional[Dict[str, Any]]:
+    """Gather and merge repository context from multiple repos."""
+    merged: Dict[str, Any] = {
+        "package_structure": [],
+        "api_files": [],
+        "controller_files": [],
+        "crd_files": [],
+        "project_types": [],
+    }
+
+    for path in repo_paths:
+        logger.info(f"Gathering repository context from: {path}")
+        try:
+            ctx = _gather_repo_context(path)
+            if ctx:
+                for key in merged:
+                    items = ctx.get(key, [])
+                    if isinstance(items, list):
+                        merged[key].extend(items)
+                if ctx.get("project_type"):
+                    merged["project_types"].append(ctx["project_type"])
+        except Exception as e:
+            logger.warning(f"Failed to gather context from {path}: {e}")
+
+    logger.info(
+        f"Merged context from {len(repo_paths)} repos: "
+        f"{len(merged['api_files'])} API files, "
+        f"{len(merged['controller_files'])} controllers, "
+        f"{len(merged['crd_files'])} CRDs, "
+        f"{len(merged['package_structure'])} packages"
+    )
+    return merged if any(merged.values()) else None
 
 
 def _build_component_context() -> str:

--- a/stages/develop.py
+++ b/stages/develop.py
@@ -38,7 +38,8 @@ class DevelopmentAgentError(Exception):
 
 def run_development(
     context: Dict[str, Any],
-    repo_path: Optional[str] = None
+    repo_path: Optional[str] = None,
+    repo_paths: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Generate production-quality Go code for Kubernetes/OpenShift features.
 
@@ -120,7 +121,7 @@ def run_development(
 
     # Build the development prompt
     logger.debug("Building development prompt")
-    user_prompt = _build_development_prompt(context, repo_path)
+    user_prompt = _build_development_prompt(context, repo_path, repo_paths)
     session_logger.debug(f"Prompt length: {len(user_prompt)} chars")
 
     # Call Claude API
@@ -357,7 +358,8 @@ def _gather_repo_context(repo_path: str, context: Dict[str, Any]) -> str:
 
 def _build_development_prompt(
     context: Dict[str, Any],
-    repo_path: Optional[str] = None
+    repo_path: Optional[str] = None,
+    repo_paths: Optional[List[str]] = None,
 ) -> str:
     """Build the user prompt for code generation.
 
@@ -427,11 +429,24 @@ def _build_development_prompt(
         for risk in risks:
             prompt_parts.append(f"- {risk}\n")
 
-    if repo_path:
+    # Resolve effective repo list
+    effective_paths = repo_paths or ([repo_path] if repo_path else [])
+
+    if effective_paths:
         prompt_parts.append(f"\n## Repository Path\n")
-        prompt_parts.append(f"{repo_path}\n")
-        # Gather actual repo context for better code generation
-        repo_context = _gather_repo_context(repo_path, context)
+        for path in effective_paths:
+            prompt_parts.append(f"{path}\n")
+
+        repo_context_parts = []
+        for path in effective_paths:
+            try:
+                ctx = _gather_repo_context(path, context)
+                if ctx:
+                    repo_context_parts.append(ctx)
+            except Exception as e:
+                logger.warning(f"Failed to gather context from {path}: {e}")
+
+        repo_context = "\n\n".join(repo_context_parts) if repo_context_parts else None
         if repo_context:
             prompt_parts.append(repo_context)
 

--- a/stages/docs.py
+++ b/stages/docs.py
@@ -64,7 +64,8 @@ def run_docs(
             - issue_title: str - Original issue title
             - issue_description: str - Original issue description
             - issue_type: str - Type of issue (bug, feature, etc.)
-            - repo_path: str - Path to repository (required for RAG)
+            - repo_path: str - Path to repository (required for RAG, single repo)
+            - repo_paths: list[str] - Paths to multiple repositories (preferred for RAG)
         input_files: Optional list of file paths to include as context
         output_format: Output format - "standard", "ship", "jtbd", or "all"
         enable_rag: Enable RAG for fetching relevant documentation
@@ -103,11 +104,13 @@ def run_docs(
     logger.debug("Context validation passed")
 
     # Initialize RAG search if enabled
+    # Support both multi-repo (repo_paths) and single-repo (repo_path) context
     rag_context = {}
-    if enable_rag and "repo_path" in context:
-        logger.info(f"RAG search enabled for repo: {context['repo_path']}")
+    repo_paths = _resolve_repo_paths(context)
+    if enable_rag and repo_paths:
+        logger.info(f"RAG search enabled for repos: {repo_paths}")
         try:
-            rag_context = _fetch_rag_context(context, input_files)
+            rag_context = _fetch_rag_context(context, input_files, repo_paths)
             logger.info(f"RAG context fetched: {list(rag_context.keys())}")
             session_logger.info(f"RAG context: {len(rag_context.get('related_docs', []))} docs, {len(rag_context.get('code_examples', []))} examples")
         except RAGSearchError as e:
@@ -118,9 +121,10 @@ def run_docs(
     input_file_context = {}
     if input_files:
         logger.info(f"Processing {len(input_files)} input files")
+        base_repo_path = repo_paths[0] if repo_paths else context.get("repo_path", ".")
         input_file_context = _process_input_files(
             input_files,
-            context.get("repo_path", ".")
+            base_repo_path
         )
         session_logger.info(f"Processed {len(input_file_context.get('file_contents', {}))} input files")
 
@@ -213,15 +217,43 @@ def run_docs(
         raise RuntimeError(f"Unexpected error in docs agent: {e}") from e
 
 
-def _fetch_rag_context(
-    context: Dict[str, Any],
-    input_files: Optional[List[str]] = None
-) -> Dict[str, Any]:
-    """Fetch relevant context using RAG search.
+def _resolve_repo_paths(context: Dict[str, Any]) -> List[str]:
+    """Resolve repository paths from context.
+
+    Supports both multi-repo (``repo_paths``) and single-repo (``repo_path``)
+    context keys, with proper fallback handling.
 
     Args:
-        context: Agent context with repo_path and files_modified
+        context: Agent context dictionary.
+
+    Returns:
+        List of repository path strings. May be empty if neither key is present.
+    """
+    repo_paths = context.get("repo_paths")
+    if repo_paths and isinstance(repo_paths, list):
+        # Filter out any empty/None entries
+        return [p for p in repo_paths if p]
+
+    single = context.get("repo_path")
+    if single:
+        return [single]
+
+    return []
+
+
+def _fetch_rag_context(
+    context: Dict[str, Any],
+    input_files: Optional[List[str]] = None,
+    repo_paths: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Fetch relevant context using RAG search across one or more repositories.
+
+    Args:
+        context: Agent context with files_modified and other metadata
         input_files: Optional input files to analyze
+        repo_paths: List of repository paths to search. When multiple paths are
+            provided, RAG results from each repo are merged (deduplicated by
+            file path).
 
     Returns:
         Dictionary with RAG context:
@@ -230,81 +262,109 @@ def _fetch_rag_context(
             - api_patterns: List of API usage patterns
             - similar_implementations: List of similar code
     """
-    repo_path = context.get("repo_path")
-    if not repo_path:
-        logger.debug("No repo_path in context, skipping RAG")
+    if not repo_paths:
+        repo_paths = _resolve_repo_paths(context)
+    if not repo_paths:
+        logger.debug("No repo paths available, skipping RAG")
         return {}
 
-    logger.debug(f"Initializing RAG search for repo: {repo_path}")
-    rag_search = RAGSearch(repo_path)
-    rag_context: Dict[str, Any] = {}
+    merged_context: Dict[str, List[Any]] = {
+        "related_docs": [],
+        "code_examples": [],
+        "similar_implementations": [],
+        "api_patterns": [],
+    }
 
-    # Search Shipwright documentation
-    if "issue_title" in context:
-        logger.debug(f"Searching Shipwright docs for: {context['issue_title']}")
-        doc_matches = rag_search.search_shipwright_docs(
-            query=context["issue_title"],
-            max_results=3
-        )
-        rag_context["related_docs"] = [
-            {
-                "file": match.file_path,
-                "section": match.section_title,
-                "content": match.content[:500]  # First 500 chars
-            }
-            for match in doc_matches
-        ]
-        logger.debug(f"Found {len(doc_matches)} related docs")
+    seen_files: Dict[str, set] = {
+        "related_docs": set(),
+        "code_examples": set(),
+        "similar_implementations": set(),
+        "api_patterns": set(),
+    }
 
-    # Extract code examples from modified files or input files
-    files_to_analyze = input_files or context.get("files_modified", [])
-    if files_to_analyze:
-        logger.debug(f"Extracting code examples from {len(files_to_analyze)} files")
-        code_examples = rag_search.extract_code_examples(files_to_analyze)
-        rag_context["code_examples"] = [
-            {
-                "file": ex.file_path,
-                "language": ex.language,
-                "context": ex.context,
-                "code": ex.code[:300]  # First 300 chars
-            }
-            for ex in code_examples[:5]  # Top 5 examples
-        ]
-        logger.debug(f"Extracted {len(code_examples)} code examples")
+    for repo_path in repo_paths:
+        logger.debug(f"Initializing RAG search for repo: {repo_path}")
+        try:
+            rag_search = RAGSearch(repo_path)
+        except RAGSearchError as e:
+            logger.warning(f"Failed to initialise RAGSearch for {repo_path}: {e}")
+            continue
 
-    # Search for similar implementations
-    if files_to_analyze:
-        logger.debug("Searching for similar code implementations")
-        similar = rag_search.search_similar_code(
-            reference_files=files_to_analyze[:3],  # Top 3 files
-            max_results=5
-        )
-        rag_context["similar_implementations"] = [
-            {"file": res.file_path, "line": res.line_number}
-            for res in similar
-        ]
-        logger.debug(f"Found {len(similar)} similar implementations")
+        try:
+            # Search Shipwright documentation
+            if "issue_title" in context:
+                logger.debug(f"Searching docs in {repo_path} for: {context['issue_title']}")
+                doc_matches = rag_search.search_shipwright_docs(
+                    query=context["issue_title"],
+                    max_results=3
+                )
+                for match in doc_matches:
+                    if match.file_path not in seen_files["related_docs"]:
+                        seen_files["related_docs"].add(match.file_path)
+                        merged_context["related_docs"].append({
+                            "file": match.file_path,
+                            "section": match.section_title,
+                            "content": match.content[:500],
+                        })
+                logger.debug(f"Found {len(doc_matches)} related docs in {repo_path}")
 
-    # Find API usage patterns (extract from design analysis)
-    api_names = _extract_api_names(context.get("design_analysis", ""))
-    if api_names:
-        logger.debug(f"Searching API patterns for: {api_names[:3]}")
-        api_patterns = rag_search.search_api_patterns(
-            api_names=api_names[:3],  # Top 3 APIs
-            file_pattern="**/*.go"
-        )
-        rag_context["api_patterns"] = [
-            {
-                "api": pattern.api_name,
-                "file": pattern.file_path,
-                "type": pattern.pattern_type,
-                "code": pattern.usage_code[:200]
-            }
-            for pattern in api_patterns[:5]  # Top 5 patterns
-        ]
-        logger.debug(f"Found {len(api_patterns)} API patterns")
+            # Extract code examples from modified files or input files
+            files_to_analyze = input_files or context.get("files_modified", [])
+            if files_to_analyze:
+                logger.debug(f"Extracting code examples from {len(files_to_analyze)} files in {repo_path}")
+                code_examples = rag_search.extract_code_examples(files_to_analyze)
+                for ex in code_examples[:5]:
+                    if ex.file_path not in seen_files["code_examples"]:
+                        seen_files["code_examples"].add(ex.file_path)
+                        merged_context["code_examples"].append({
+                            "file": ex.file_path,
+                            "language": ex.language,
+                            "context": ex.context,
+                            "code": ex.code[:300],
+                        })
+                logger.debug(f"Extracted {len(code_examples)} code examples from {repo_path}")
 
-    return rag_context
+            # Search for similar implementations
+            if files_to_analyze:
+                logger.debug(f"Searching for similar code in {repo_path}")
+                similar = rag_search.search_similar_code(
+                    reference_files=files_to_analyze[:3],
+                    max_results=5
+                )
+                for res in similar:
+                    key = f"{res.file_path}:{res.line_number}"
+                    if key not in seen_files["similar_implementations"]:
+                        seen_files["similar_implementations"].add(key)
+                        merged_context["similar_implementations"].append(
+                            {"file": res.file_path, "line": res.line_number}
+                        )
+                logger.debug(f"Found {len(similar)} similar implementations in {repo_path}")
+
+            # Find API usage patterns (extract from design analysis)
+            api_names = _extract_api_names(context.get("design_analysis", ""))
+            if api_names:
+                logger.debug(f"Searching API patterns in {repo_path} for: {api_names[:3]}")
+                api_patterns = rag_search.search_api_patterns(
+                    api_names=api_names[:3],
+                    file_pattern="**/*.go"
+                )
+                for pattern in api_patterns[:5]:
+                    key = f"{pattern.api_name}:{pattern.file_path}"
+                    if key not in seen_files["api_patterns"]:
+                        seen_files["api_patterns"].add(key)
+                        merged_context["api_patterns"].append({
+                            "api": pattern.api_name,
+                            "file": pattern.file_path,
+                            "type": pattern.pattern_type,
+                            "code": pattern.usage_code[:200],
+                        })
+                logger.debug(f"Found {len(api_patterns)} API patterns in {repo_path}")
+        except Exception as e:
+            logger.warning(f"RAG search failed for {repo_path}: {e}")
+            continue
+
+    # Only return keys that have results
+    return {k: v for k, v in merged_context.items() if v}
 
 
 def _extract_api_names(design_text: str) -> List[str]:


### PR DESCRIPTION
## Summary
- Pipeline now loads and analyzes **all repos** defined in `repos.yaml`, not just the first one
- `WorkflowOrchestrator` accepts `repo_paths: list[str]` alongside `repo_path` for backward compatibility
- Design stage merges context (API files, controllers, CRDs, packages) from all repos into a combined analysis
- Development stage gathers repo context from all repos and joins into a single prompt
- Docs stage runs RAG search across all repos with deduplication
- Per-repo error handling: one bad repo logs a warning and continues, doesn't kill the pipeline

## Files Changed
- `orchestrator/workflow.py` — accepts `repo_paths`, passes to stages
- `scripts/orchestrate.py` — passes full repo list to orchestrator
- `stages/design.py` — new `_gather_multi_repo_context()` merges across repos
- `stages/develop.py` — iterates repos for context gathering
- `stages/docs.py` — multi-repo RAG search with deduplication

## Test plan
- [x] 794 tests pass, 0 failures
- [ ] Run pipeline with multiple repos in repos.yaml, verify all are analyzed in design log

Closes #139