### PR TITLE
fix(tools): return empty list for missing pkg/ directory instead of raising error

### DIFF
--- a/tools/repo_search.py
+++ b/tools/repo_search.py
@@ -354,7 +354,7 @@ class RepoSearch:
         search_path = self.repo_path / base_path if base_path else self.repo_path
 
         if not search_path.exists():
-            raise RepositorySearchError(f"Path does not exist: {search_path}")
+            return []
 
         packages: Dict[str, PackageInfo] = {}
 


### PR DESCRIPTION
## Summary
- `analyze_go_packages()` now returns an empty list when the target directory doesn't exist, instead of raising `RepositorySearchError`
- Not all Go repos have a `pkg/` directory (some use `internal/` or flat structure)
- Eliminates noisy warning tracebacks in the design stage log when scanning multiple repos

## Test plan
- [x] Non-breaking change — callers already handle empty results