### PR TITLE
feat(pipeline): respect language field from repos.yaml (#139)

### DIFF
--- a/config/repo_config.py
+++ b/config/repo_config.py
@@ -81,6 +81,55 @@ def _deduplicated(paths: list[str]) -> list[str]:
     return result
 
 
+def load_repo_entries(
+    cli_repo_path: str | None = None,
+    project_root: str | None = None,
+) -> list[dict]:
+    """Load repo entries with metadata (path, language).
+
+    Returns a list of dicts with ``"path"`` and optional ``"language"`` keys.
+    Precedence: CLI argument > repos.yaml > environment variables.
+    Entries are deduplicated by resolved path (first occurrence wins)
+    and non-existent directories are skipped with a warning.
+    """
+    if os.getenv("ENABLE_REPO_ANALYSIS", "true").lower() == "false":
+        logger.info("Repository analysis disabled (ENABLE_REPO_ANALYSIS=false)")
+        return []
+
+    root = _resolve_project_root(project_root)
+    yaml_path = root / _DEFAULT_YAML_NAME
+    config = load_repo_config(yaml_path)
+
+    entries: list[dict] = []
+
+    # Highest priority: CLI argument
+    if cli_repo_path:
+        entries.append({"path": cli_repo_path, "language": None})
+
+    # repos.yaml entries (preserve language metadata)
+    for entry in config.repos:
+        entries.append({"path": entry.path, "language": entry.language})
+
+    # Env var fallback
+    for p in _env_var_paths():
+        entries.append({"path": p, "language": None})
+
+    # Deduplicate by resolved path, keeping first occurrence
+    seen: set[str] = set()
+    unique: list[dict] = []
+    for e in entries:
+        resolved = str(Path(e["path"]).resolve())
+        if resolved not in seen:
+            seen.add(resolved)
+            if Path(resolved).is_dir():
+                unique.append({"path": resolved, "language": e["language"]})
+            else:
+                logger.warning("Repo path does not exist, skipping: %s", resolved)
+
+    logger.info("Loaded %d repo entries for analysis", len(unique))
+    return unique
+
+
 def load_repo_paths(
     cli_repo_path: str | None = None,
     project_root: str | None = None,

--- a/models/workflow_state.py
+++ b/models/workflow_state.py
@@ -61,6 +61,7 @@ class WorkflowState(TypedDict, total=False):
     # Repository context
     repo_path: str
     repo_paths: list[str]
+    repo_entries: list[dict]
     target_branch: str
 
     # Jira integration

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -188,6 +188,7 @@ class WorkflowOrchestrator:
             description=state["issue_description"],
             repo_path=state.get("repo_path"),
             repo_paths=state.get("repo_paths", []),
+            repo_entries=state.get("repo_entries"),
         )
 
     def _run_develop(self, state: Dict[str, Any]) -> Dict[str, Any]:

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -31,7 +31,7 @@ from orchestrator.workflow import WorkflowOrchestrator
 # Excluded from extra_state to avoid duplication.
 _CORE_STATE_KEYS = frozenset({
     "session_id", "issue_title", "issue_description", "issue_type",
-    "repo_path", "repo_paths", "current_phase",
+    "repo_path", "repo_paths", "repo_entries", "current_phase",
 })
 
 
@@ -222,8 +222,9 @@ def orchestrate(
     pipeline_start = time.time()
 
     # Build repo_paths from repos.yaml, env vars, and CLI arg
-    from config.repo_config import load_repo_paths
+    from config.repo_config import load_repo_entries, load_repo_paths
     repo_paths = load_repo_paths(cli_repo_path=repo_path)
+    repo_entries = load_repo_entries(cli_repo_path=repo_path)
     # Use first repo_path as primary for backward compatibility
     repo_path = repo_paths[0] if repo_paths else None
 
@@ -250,6 +251,7 @@ def orchestrate(
         "issue_type": issue_type,
         "repo_path": repo_path,
         "repo_paths": repo_paths,
+        "repo_entries": repo_entries,
         "current_phase": "init",
     }
 

--- a/stages/design.py
+++ b/stages/design.py
@@ -39,6 +39,7 @@ def run_design(
     description: str,
     repo_path: Optional[str] = None,
     repo_paths: Optional[List[str]] = None,
+    repo_entries: Optional[List[dict]] = None,
 ) -> Dict[str, Any]:
     """Run design analysis on a GitHub issue.
 
@@ -53,6 +54,9 @@ def run_design(
                   If not provided, analysis is based on component metadata only.
         repo_paths: Optional list of repository paths to gather context from.
                    When provided, takes precedence over repo_path.
+        repo_entries: Optional list of repo entry dicts (``{"path": ..., "language": ...}``).
+                     When provided, takes precedence over repo_paths and repo_path
+                     so that per-repo language metadata is preserved.
 
     Returns:
         Dictionary containing:
@@ -83,11 +87,15 @@ def run_design(
         logger.error(f"Failed to initialize Claude client: {e}", exc_info=True)
         raise DesignAgentError(f"Failed to initialize Claude client: {e}") from e
 
-    # Resolve effective repo list: prefer repo_paths, fall back to repo_path
-    effective_paths = repo_paths or ([repo_path] if repo_path else [])
+    # Resolve effective repo list: prefer repo_entries > repo_paths > repo_path
+    effective_entries: List = (
+        repo_entries
+        or repo_paths
+        or ([repo_path] if repo_path else [])
+    )
 
-    if effective_paths:
-        repo_context = _gather_multi_repo_context(effective_paths)
+    if effective_entries:
+        repo_context = _gather_multi_repo_context(effective_entries)
     else:
         logger.info("No repository paths provided, skipping repository context")
         repo_context = None
@@ -209,18 +217,25 @@ def _detect_project_type(repo_path: str) -> str:
     return "go_generic"
 
 
-def _gather_repo_context(repo_path: str) -> Dict[str, Any]:
+def _gather_repo_context(
+    repo_path: str, language: Optional[str] = None
+) -> Dict[str, Any]:
     """Gather relevant context from the repository.
 
     Automatically detects the project type and uses appropriate search patterns.
+    When *language* is explicitly set to a non-Go value (e.g. ``"python"``),
+    Go-specific analysis (API types, controllers, CRDs, Go packages) is skipped.
 
     Args:
         repo_path: Path to the repository
+        language: Optional language hint from repos.yaml.  When ``None`` or
+            ``"go"`` the existing Go auto-detection runs.  Any other value
+            skips Go-specific analysis.
 
     Returns:
         Dictionary containing repository insights
     """
-    context = {
+    context: Dict[str, Any] = {
         "package_structure": [],
         "api_files": [],
         "controller_files": [],
@@ -228,10 +243,20 @@ def _gather_repo_context(repo_path: str) -> Dict[str, Any]:
         "project_type": "unknown",
     }
 
+    # When the language is explicitly non-Go, skip Go-specific analysis
+    if language is not None and language != "go":
+        context["project_type"] = language
+        logger.info(
+            "Repo language is '%s'; skipping Go-specific analysis for %s",
+            language,
+            repo_path,
+        )
+        return context
+
     try:
         searcher = RepoSearch(repo_path)
 
-        # Auto-detect project type
+        # Auto-detect project type (only reached for Go / unknown repos)
         project_type = _detect_project_type(repo_path)
         patterns = REPO_PATTERNS.get(project_type, REPO_PATTERNS["go_generic"])
         context["project_type"] = patterns["name"]
@@ -281,8 +306,19 @@ def _gather_repo_context(repo_path: str) -> Dict[str, Any]:
     return context
 
 
-def _gather_multi_repo_context(repo_paths: List[str]) -> Optional[Dict[str, Any]]:
-    """Gather and merge repository context from multiple repos."""
+def _gather_multi_repo_context(
+    repo_entries: List,
+) -> Optional[Dict[str, Any]]:
+    """Gather and merge repository context from multiple repos.
+
+    Args:
+        repo_entries: A list of repo entries.  Each element may be a plain
+            path string (backward compatible) **or** a dict with ``"path"``
+            and optional ``"language"`` keys.
+
+    Returns:
+        Merged context dict, or ``None`` when every repo yielded nothing.
+    """
     merged: Dict[str, Any] = {
         "package_structure": [],
         "api_files": [],
@@ -291,10 +327,18 @@ def _gather_multi_repo_context(repo_paths: List[str]) -> Optional[Dict[str, Any]
         "project_types": [],
     }
 
-    for path in repo_paths:
+    for entry in repo_entries:
+        # Support both plain strings and dicts
+        if isinstance(entry, str):
+            path = entry
+            language = None
+        else:
+            path = entry.get("path", "")
+            language = entry.get("language")
+
         logger.info(f"Gathering repository context from: {path}")
         try:
-            ctx = _gather_repo_context(path)
+            ctx = _gather_repo_context(path, language=language)
             if ctx:
                 for key in merged:
                     items = ctx.get(key, [])
@@ -306,7 +350,7 @@ def _gather_multi_repo_context(repo_paths: List[str]) -> Optional[Dict[str, Any]
             logger.warning(f"Failed to gather context from {path}: {e}")
 
     logger.info(
-        f"Merged context from {len(repo_paths)} repos: "
+        f"Merged context from {len(repo_entries)} repos: "
         f"{len(merged['api_files'])} API files, "
         f"{len(merged['controller_files'])} controllers, "
         f"{len(merged['crd_files'])} CRDs, "

--- a/tests/test_agents_validator_design.py
+++ b/tests/test_agents_validator_design.py
@@ -15,6 +15,7 @@ from stages.design import (
     run_design,
     DesignAgentError,
     _gather_repo_context,
+    _gather_multi_repo_context,
     _build_component_context,
     _build_analysis_prompt,
     _parse_design_output,
@@ -420,6 +421,140 @@ def test_integration_with_real_components(sample_repo_context):
     assert len(prompt) > 1000  # Should be substantial
     assert "Component Information" in prompt
     assert "Repository Context" in prompt
+
+
+class TestLanguageAwareRepoContext:
+    """Tests for language-aware repository context gathering."""
+
+    def test_gather_repo_context_skips_go_for_python(self):
+        """When language='python', Go-specific analysis is skipped entirely."""
+        # No RepoSearch should be instantiated for non-Go repos
+        with patch("stages.design.RepoSearch") as mock_repo_search:
+            context = _gather_repo_context("/fake/python/repo", language="python")
+
+            mock_repo_search.assert_not_called()
+            assert context["project_type"] == "python"
+            assert context["api_files"] == []
+            assert context["controller_files"] == []
+            assert context["crd_files"] == []
+            assert context["package_structure"] == []
+
+    def test_gather_repo_context_runs_go_when_language_is_go(self):
+        """When language='go', normal Go analysis runs."""
+        with patch("stages.design.RepoSearch") as mock_repo_search:
+            mock_searcher = Mock()
+            mock_searcher.search_files.return_value = []
+            mock_searcher.find_kubernetes_crds.return_value = []
+            mock_searcher.analyze_go_packages.return_value = []
+            mock_repo_search.return_value = mock_searcher
+
+            context = _gather_repo_context("/fake/go/repo", language="go")
+
+            mock_repo_search.assert_called_once_with("/fake/go/repo")
+            # project_type is set by _detect_project_type, not "go" literally
+            assert context["project_type"] in ("Go", "Go/Kubernetes")
+
+    def test_gather_repo_context_runs_go_when_language_is_none(self):
+        """When language=None (default), normal Go auto-detection runs."""
+        with patch("stages.design.RepoSearch") as mock_repo_search:
+            mock_searcher = Mock()
+            mock_searcher.search_files.return_value = []
+            mock_searcher.find_kubernetes_crds.return_value = []
+            mock_searcher.analyze_go_packages.return_value = []
+            mock_repo_search.return_value = mock_searcher
+
+            context = _gather_repo_context("/fake/repo", language=None)
+
+            mock_repo_search.assert_called_once()
+
+    def test_gather_multi_repo_context_with_mixed_languages(self):
+        """Multi-repo context gathers correctly when repos have different languages."""
+        go_api_file = "pkg/apis/build/v1beta1/build_types.go"
+
+        with patch("stages.design.RepoSearch") as mock_repo_search:
+            mock_searcher = Mock()
+            mock_searcher.search_files.return_value = [
+                Mock(file_path=go_api_file),
+            ]
+            mock_searcher.find_kubernetes_crds.return_value = []
+            mock_searcher.analyze_go_packages.return_value = []
+            mock_repo_search.return_value = mock_searcher
+
+            entries = [
+                {"path": "/fake/go/repo", "language": "go"},
+                {"path": "/fake/python/repo", "language": "python"},
+            ]
+
+            result = _gather_multi_repo_context(entries)
+
+            assert result is not None
+            # Go repo contributes API files; Python repo does not
+            assert go_api_file in result["api_files"]
+            # Both project types should be recorded
+            assert "python" in result["project_types"]
+
+    def test_gather_multi_repo_context_backward_compat_strings(self):
+        """_gather_multi_repo_context still works with plain string paths."""
+        with patch("stages.design.RepoSearch") as mock_repo_search:
+            mock_searcher = Mock()
+            mock_searcher.search_files.return_value = []
+            mock_searcher.find_kubernetes_crds.return_value = []
+            mock_searcher.analyze_go_packages.return_value = []
+            mock_repo_search.return_value = mock_searcher
+
+            result = _gather_multi_repo_context(["/fake/repo"])
+
+            mock_repo_search.assert_called_once_with("/fake/repo")
+
+    def test_run_design_uses_repo_entries(self):
+        """run_design prefers repo_entries over repo_paths when provided."""
+        mock_response = Mock()
+        mock_response.content = [Mock(text=SAMPLE_DESIGN_OUTPUT)]
+
+        with patch("stages.design.get_anthropic_client") as mock_get_client:
+            with patch("stages.design._gather_multi_repo_context") as mock_gather:
+                mock_gather.return_value = None
+                mock_client = Mock()
+                mock_client.messages.create.return_value = mock_response
+                mock_get_client.return_value = mock_client
+
+                with patch.dict(os.environ, {"ANTHROPIC_VERTEX_PROJECT_ID": "test-project-id"}):
+                    entries = [
+                        {"path": "/fake/go", "language": "go"},
+                        {"path": "/fake/py", "language": "python"},
+                    ]
+                    run_design(
+                        title=SAMPLE_ISSUE_TITLE,
+                        description=SAMPLE_ISSUE_DESCRIPTION,
+                        repo_paths=["/fake/go", "/fake/py"],
+                        repo_entries=entries,
+                    )
+
+                    # Should be called with entries (dicts), not plain paths
+                    mock_gather.assert_called_once_with(entries)
+
+    def test_run_design_falls_back_to_repo_paths(self):
+        """run_design falls back to repo_paths when repo_entries is None."""
+        mock_response = Mock()
+        mock_response.content = [Mock(text=SAMPLE_DESIGN_OUTPUT)]
+
+        with patch("stages.design.get_anthropic_client") as mock_get_client:
+            with patch("stages.design._gather_multi_repo_context") as mock_gather:
+                mock_gather.return_value = None
+                mock_client = Mock()
+                mock_client.messages.create.return_value = mock_response
+                mock_get_client.return_value = mock_client
+
+                with patch.dict(os.environ, {"ANTHROPIC_VERTEX_PROJECT_ID": "test-project-id"}):
+                    run_design(
+                        title=SAMPLE_ISSUE_TITLE,
+                        description=SAMPLE_ISSUE_DESCRIPTION,
+                        repo_paths=["/fake/go", "/fake/py"],
+                        repo_entries=None,
+                    )
+
+                    # Should be called with plain paths (backward compat)
+                    mock_gather.assert_called_once_with(["/fake/go", "/fake/py"])
 
 
 if __name__ == "__main__":

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -10,7 +10,7 @@ import logging
 import pytest
 import yaml
 
-from config.repo_config import load_repo_paths
+from config.repo_config import load_repo_entries, load_repo_paths
 
 
 # ---------------------------------------------------------------------------
@@ -328,3 +328,157 @@ def test_yaml_entry_without_path_key(tmp_path, monkeypatch, caplog):
 
     assert result == []
     assert any("validation failed" in msg.lower() for msg in caplog.messages)
+
+
+# ===========================================================================
+# load_repo_entries tests
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# 14. load_repo_entries returns dicts with path and language
+# ---------------------------------------------------------------------------
+
+def test_entries_returns_path_and_language(tmp_path, monkeypatch):
+    """load_repo_entries returns dicts with 'path' and 'language' keys."""
+    monkeypatch.delenv("SHIPWRIGHT_REPO_PATH", raising=False)
+    monkeypatch.delenv("OPENSHIFT_BUILDS_REPO_PATH", raising=False)
+    monkeypatch.delenv("ENABLE_REPO_ANALYSIS", raising=False)
+
+    dirs = _make_repo_dirs(tmp_path, ["go-repo", "py-repo"])
+    _write_repos_yaml(tmp_path, {
+        "repos": [
+            {"path": dirs[0], "language": "go"},
+            {"path": dirs[1], "language": "python"},
+        ]
+    })
+
+    result = load_repo_entries(project_root=str(tmp_path))
+
+    assert len(result) == 2
+    assert result[0]["path"] == dirs[0]
+    assert result[0]["language"] == "go"
+    assert result[1]["path"] == dirs[1]
+    assert result[1]["language"] == "python"
+
+
+# ---------------------------------------------------------------------------
+# 15. load_repo_entries preserves None language when not specified
+# ---------------------------------------------------------------------------
+
+def test_entries_language_defaults_to_none(tmp_path, monkeypatch):
+    """When repos.yaml omits the language field, entries have language=None."""
+    monkeypatch.delenv("SHIPWRIGHT_REPO_PATH", raising=False)
+    monkeypatch.delenv("OPENSHIFT_BUILDS_REPO_PATH", raising=False)
+    monkeypatch.delenv("ENABLE_REPO_ANALYSIS", raising=False)
+
+    dirs = _make_repo_dirs(tmp_path, ["repo-no-lang"])
+    _write_repos_yaml(tmp_path, {"repos": [{"path": dirs[0]}]})
+
+    result = load_repo_entries(project_root=str(tmp_path))
+
+    assert len(result) == 1
+    assert result[0]["language"] is None
+
+
+# ---------------------------------------------------------------------------
+# 16. load_repo_entries CLI arg gets language=None
+# ---------------------------------------------------------------------------
+
+def test_entries_cli_arg_has_no_language(tmp_path, monkeypatch):
+    """CLI argument entries have language=None since they lack metadata."""
+    monkeypatch.delenv("SHIPWRIGHT_REPO_PATH", raising=False)
+    monkeypatch.delenv("OPENSHIFT_BUILDS_REPO_PATH", raising=False)
+    monkeypatch.delenv("ENABLE_REPO_ANALYSIS", raising=False)
+
+    dirs = _make_repo_dirs(tmp_path, ["cli-repo"])
+
+    result = load_repo_entries(cli_repo_path=dirs[0], project_root=str(tmp_path))
+
+    assert len(result) == 1
+    assert result[0]["path"] == dirs[0]
+    assert result[0]["language"] is None
+
+
+# ---------------------------------------------------------------------------
+# 17. load_repo_entries deduplicates and keeps first occurrence
+# ---------------------------------------------------------------------------
+
+def test_entries_deduplication_keeps_first(tmp_path, monkeypatch):
+    """When the same path appears from CLI and YAML, CLI (first) wins."""
+    monkeypatch.delenv("SHIPWRIGHT_REPO_PATH", raising=False)
+    monkeypatch.delenv("OPENSHIFT_BUILDS_REPO_PATH", raising=False)
+    monkeypatch.delenv("ENABLE_REPO_ANALYSIS", raising=False)
+
+    dirs = _make_repo_dirs(tmp_path, ["shared"])
+    _write_repos_yaml(tmp_path, {
+        "repos": [{"path": dirs[0], "language": "go"}]
+    })
+
+    result = load_repo_entries(cli_repo_path=dirs[0], project_root=str(tmp_path))
+
+    assert len(result) == 1
+    # CLI entry (language=None) takes precedence over YAML (language="go")
+    assert result[0]["language"] is None
+
+
+# ---------------------------------------------------------------------------
+# 18. load_repo_entries respects ENABLE_REPO_ANALYSIS=false
+# ---------------------------------------------------------------------------
+
+def test_entries_enable_repo_analysis_false(tmp_path, monkeypatch):
+    """Setting ENABLE_REPO_ANALYSIS=false returns empty list."""
+    dirs = _make_repo_dirs(tmp_path, ["a-repo"])
+    _write_repos_yaml(tmp_path, {
+        "repos": [{"path": dirs[0], "language": "go"}]
+    })
+    monkeypatch.setenv("ENABLE_REPO_ANALYSIS", "false")
+    monkeypatch.delenv("SHIPWRIGHT_REPO_PATH", raising=False)
+    monkeypatch.delenv("OPENSHIFT_BUILDS_REPO_PATH", raising=False)
+
+    result = load_repo_entries(project_root=str(tmp_path))
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 19. load_repo_entries env var entries have language=None
+# ---------------------------------------------------------------------------
+
+def test_entries_env_var_has_no_language(tmp_path, monkeypatch):
+    """Env var fallback paths have language=None."""
+    monkeypatch.delenv("ENABLE_REPO_ANALYSIS", raising=False)
+
+    dirs = _make_repo_dirs(tmp_path, ["env-repo"])
+    monkeypatch.setenv("SHIPWRIGHT_REPO_PATH", dirs[0])
+    monkeypatch.delenv("OPENSHIFT_BUILDS_REPO_PATH", raising=False)
+
+    empty_root = tmp_path / "empty-root"
+    empty_root.mkdir()
+
+    result = load_repo_entries(project_root=str(empty_root))
+
+    assert len(result) == 1
+    assert result[0]["language"] is None
+
+
+# ---------------------------------------------------------------------------
+# 20. load_repo_entries skips non-existent paths
+# ---------------------------------------------------------------------------
+
+def test_entries_skips_nonexistent(tmp_path, monkeypatch, caplog):
+    """Non-existent paths are excluded from entries."""
+    monkeypatch.delenv("SHIPWRIGHT_REPO_PATH", raising=False)
+    monkeypatch.delenv("OPENSHIFT_BUILDS_REPO_PATH", raising=False)
+    monkeypatch.delenv("ENABLE_REPO_ANALYSIS", raising=False)
+
+    fake = str(tmp_path / "does-not-exist")
+    _write_repos_yaml(tmp_path, {
+        "repos": [{"path": fake, "language": "go"}]
+    })
+
+    with caplog.at_level(logging.WARNING, logger="config.repo_config"):
+        result = load_repo_entries(project_root=str(tmp_path))
+
+    assert result == []
+    assert any("does not exist" in msg for msg in caplog.messages)


### PR DESCRIPTION
## Summary
- Pipeline now respects the `language` field in `repos.yaml` entries
- Python repos skip Go-specific analysis (CRDs, controllers, Go packages)
- Added `load_repo_entries()` to return repo metadata (path + language) alongside existing `load_repo_paths()`
- `repo_entries` flows through the full pipeline: orchestrate.py → state → orchestrator → design stage
- Backward compatible — falls back to auto-detection when language is not specified

## Files Changed
- `config/repo_config.py` — new `load_repo_entries()` function
- `stages/design.py` — language-aware `_gather_repo_context()`, updated `_gather_multi_repo_context()`
- `orchestrator/workflow.py` — passes `repo_entries` to design stage
- `scripts/orchestrate.py` — loads and stores repo entries in state
- `models/workflow_state.py` — added `repo_entries` field
- `tests/test_repo_config.py` — 7 new tests for `load_repo_entries()`
- `tests/test_agents_validator_design.py` — 7 new tests for language-aware context

## Test plan
- [x] 808 tests pass (14 new tests added), 0 failures

Closes #139