### PR TITLE
feat: add local-first persistent memory layer for agents (#90)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -245,4 +245,11 @@ GITHUB_REQUEST_TIMEOUT=10
 #    - CI/headless: set QODO_API_KEY instead (no browser needed)
 #    - Claude Code: Qodo requires --ci flag to bypass interactive TUI
 #      (handled automatically when QODO_CLI_PATH is configured)
+
+# ----------------------------------------------------------------------------
+# Memory Layer (cross-session agent learning)
+# ----------------------------------------------------------------------------
+MEMORY_ENABLED=false
+MEMORY_DB_PATH=~/.local/share/flowpilot/memory.db
+
 # ============================================================================

--- a/.env.example
+++ b/.env.example
@@ -215,6 +215,15 @@ GITHUB_TOKEN=your-github-token-here
 GITHUB_REQUEST_TIMEOUT=10
 
 # ----------------------------------------------------------------------------
+# Memory Layer (cross-session agent learning)
+# ----------------------------------------------------------------------------
+MEMORY_ENABLED=false
+MEMORY_DB_PATH=~/.local/share/flowpilot/memory.db
+
+# ============================================================================
+
+
+# ----------------------------------------------------------------------------
 # Notes
 # ----------------------------------------------------------------------------
 # 1. Authentication:
@@ -245,11 +254,3 @@ GITHUB_REQUEST_TIMEOUT=10
 #    - CI/headless: set QODO_API_KEY instead (no browser needed)
 #    - Claude Code: Qodo requires --ci flag to bypass interactive TUI
 #      (handled automatically when QODO_CLI_PATH is configured)
-
-# ----------------------------------------------------------------------------
-# Memory Layer (cross-session agent learning)
-# ----------------------------------------------------------------------------
-MEMORY_ENABLED=false
-MEMORY_DB_PATH=~/.local/share/flowpilot/memory.db
-
-# ============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,3 +122,5 @@ Tests are in `tests/` and use pytest. The `conftest.py` provides shared fixtures
 | `PII_REDACTION_ENABLED` | Redact PII from Jira/GitHub data at fetch time (default: `true`). Set to `false` for local dev only. |
 | `PROMPT_GUARD_ENABLED` | Sanitize external text for prompt injection patterns before prompt assembly (default: `true`). Set to `false` for local dev only. |
 | `OUTPUT_SANITIZER_ENABLED` | Enable/disable output sanitizer (default: `true`) |
+| `MEMORY_ENABLED` | Enable cross-session agent memory (default: `false`) |
+| `MEMORY_DB_PATH` | SQLite DB path for memory (default: `~/.local/share/flowpilot/memory.db`) |

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,0 +1,13 @@
+"""Persistent memory layer for SDLC pipeline execution."""
+
+from memory.models import MemoryEntry, MemoryQuery, MemoryType
+from memory.service import MemoryService
+from memory.store import MemoryStore
+
+__all__ = [
+    "MemoryEntry",
+    "MemoryQuery",
+    "MemoryService",
+    "MemoryStore",
+    "MemoryType",
+]

--- a/memory/extractor.py
+++ b/memory/extractor.py
@@ -1,0 +1,239 @@
+"""Rule-based extraction of memory entries from stage outputs.
+
+Purely deterministic -- no Claude API calls.  Each stage has a small
+helper that inspects the stage output dict and yields ``MemoryEntry``
+objects according to hard-coded rules.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from memory.models import MemoryEntry, MemoryType
+
+_MAX_CONTENT_LEN = 500
+
+# Type alias for per-stage extractor functions.
+_Extractor = Callable[[dict, dict], list[MemoryEntry]]
+
+
+def extract_memories(
+    stage: str,
+    context: dict,
+    stage_output: dict,
+) -> list[MemoryEntry]:
+    """Extract memory entries from a stage's output.
+
+    Uses rule-based extraction -- no API calls.
+
+    Parameters
+    ----------
+    stage:
+        Pipeline stage name (``design``, ``develop``, ``testing``, ``docs``).
+    context:
+        Shared pipeline context dict carrying ``session_id``,
+        ``issue_title``, ``issue_type``, ``impacted_components``, etc.
+    stage_output:
+        The dict returned by the stage runner.
+
+    Returns
+    -------
+    list[MemoryEntry]
+        Zero or more memory entries extracted from *stage_output*.
+    """
+    extractors: dict[str, _Extractor] = {
+        "design": _extract_design,
+        "develop": _extract_develop,
+        "testing": _extract_testing,
+        "docs": _extract_docs,
+    }
+    extractor = extractors.get(stage)
+    if extractor is None:
+        return []
+    return extractor(context, stage_output)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _common_fields(context: dict, stage: str) -> dict:
+    """Return the fields shared by every ``MemoryEntry`` we create."""
+    return {
+        "session_id": context.get("session_id", ""),
+        "stage": stage,
+        "issue_title": context.get("issue_title", "") or None,
+        "issue_type": context.get("issue_type", "") or None,
+        "tags": list(context.get("impacted_components", [])),
+    }
+
+
+def _make_entry(
+    context: dict,
+    stage: str,
+    memory_type: MemoryType,
+    title: str,
+    content: str,
+) -> MemoryEntry | None:
+    """Build a ``MemoryEntry`` if *content* is non-empty."""
+    content = content.strip()
+    if not content:
+        return None
+    return MemoryEntry(
+        memory_type=memory_type,
+        title=title,
+        content=content,
+        **_common_fields(context, stage),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-stage extractors
+# ---------------------------------------------------------------------------
+
+def _extract_design(context: dict, output: dict) -> list[MemoryEntry]:
+    entries: list[MemoryEntry] = []
+    issue_title = context.get("issue_title", "")
+
+    # Reusable context from design_analysis (truncated)
+    design_analysis: str = output.get("design_analysis", "")
+    entry = _make_entry(
+        context,
+        "design",
+        MemoryType.reusable_context,
+        f"Design: {issue_title}",
+        design_analysis[:_MAX_CONTENT_LEN],
+    )
+    if entry:
+        entries.append(entry)
+
+    # Heuristic for each risk
+    risks: list[str] = output.get("risks", [])
+    for risk in risks:
+        entry = _make_entry(
+            context,
+            "design",
+            MemoryType.heuristic,
+            f"Risk: {risk[:80]}",
+            risk,
+        )
+        if entry:
+            entries.append(entry)
+
+    # Best practice summarising implementation plan
+    plan: list[str] = output.get("implementation_plan", [])
+    if plan:
+        plan_summary = "\n".join(f"- {step}" for step in plan)
+        entry = _make_entry(
+            context,
+            "design",
+            MemoryType.best_practice,
+            f"Implementation approach for {issue_title}",
+            plan_summary,
+        )
+        if entry:
+            entries.append(entry)
+
+    return entries
+
+
+def _extract_develop(context: dict, output: dict) -> list[MemoryEntry]:
+    entries: list[MemoryEntry] = []
+    issue_title = context.get("issue_title", "")
+
+    # Execution note listing generated files
+    code_files: list[dict] = output.get("code_files", [])
+    test_files: list[dict] = output.get("test_files", [])
+    all_paths = [f.get("path", "") for f in code_files + test_files if f.get("path")]
+    if all_paths:
+        content = "\n".join(all_paths)
+        entry = _make_entry(
+            context,
+            "develop",
+            MemoryType.execution_note,
+            f"Dev output: {issue_title}",
+            content,
+        )
+        if entry:
+            entries.append(entry)
+
+    # Anti-patterns from review findings when review failed
+    review_passed: bool = output.get("review_passed", True)
+    review_findings: list[str] = output.get("review_findings", [])
+    if not review_passed and review_findings:
+        for finding in review_findings:
+            entry = _make_entry(
+                context,
+                "develop",
+                MemoryType.anti_pattern,
+                f"Review finding: {finding[:80]}",
+                finding,
+            )
+            if entry:
+                entries.append(entry)
+
+    # Security best practice
+    security_notes: str = output.get("security_notes", "")
+    if security_notes.strip():
+        entry = _make_entry(
+            context,
+            "develop",
+            MemoryType.best_practice,
+            f"Security: {issue_title}",
+            security_notes,
+        )
+        if entry:
+            entries.append(entry)
+
+    return entries
+
+
+def _extract_testing(context: dict, output: dict) -> list[MemoryEntry]:
+    entries: list[MemoryEntry] = []
+    issue_title = context.get("issue_title", "")
+
+    # Reusable context from test plan (truncated)
+    test_plan: str = output.get("test_plan", "")
+    entry = _make_entry(
+        context,
+        "testing",
+        MemoryType.reusable_context,
+        f"Test plan: {issue_title}",
+        test_plan[:_MAX_CONTENT_LEN],
+    )
+    if entry:
+        entries.append(entry)
+
+    # Heuristic from coverage analysis
+    coverage: str = output.get("coverage_analysis", "")
+    if coverage.strip():
+        entry = _make_entry(
+            context,
+            "testing",
+            MemoryType.heuristic,
+            f"Coverage: {issue_title}",
+            coverage,
+        )
+        if entry:
+            entries.append(entry)
+
+    return entries
+
+
+def _extract_docs(context: dict, output: dict) -> list[MemoryEntry]:
+    entries: list[MemoryEntry] = []
+    issue_title = context.get("issue_title", "")
+
+    # Reusable context from PR summary
+    pr_summary: str = output.get("pr_summary", "")
+    entry = _make_entry(
+        context,
+        "docs",
+        MemoryType.reusable_context,
+        f"PR summary: {issue_title}",
+        pr_summary,
+    )
+    if entry:
+        entries.append(entry)
+
+    return entries

--- a/memory/models.py
+++ b/memory/models.py
@@ -1,0 +1,54 @@
+"""Data models for the persistent memory layer."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, field_validator
+
+
+VALID_STAGES = ["design", "develop", "testing", "docs"]
+
+
+class MemoryType(StrEnum):
+    """Categories of memories captured during pipeline execution."""
+
+    best_practice = "best_practice"
+    anti_pattern = "anti_pattern"
+    heuristic = "heuristic"
+    execution_note = "execution_note"
+    reusable_context = "reusable_context"
+
+
+class MemoryEntry(BaseModel):
+    """A single memory captured during a pipeline run."""
+
+    id: int | None = None
+    session_id: str
+    stage: str
+    memory_type: MemoryType
+    title: str
+    content: str
+    tags: list[str] = []
+    issue_title: str | None = None
+    issue_type: str | None = None
+    created_at: str | None = None
+    relevance_score: float = 1.0
+
+    @field_validator("stage")
+    @classmethod
+    def _validate_stage(cls, value: str) -> str:
+        if value not in VALID_STAGES:
+            msg = f"stage must be one of {VALID_STAGES}, got '{value}'"
+            raise ValueError(msg)
+        return value
+
+
+class MemoryQuery(BaseModel):
+    """Query parameters for retrieving memories."""
+
+    query_text: str
+    stage: str | None = None
+    memory_types: list[MemoryType] | None = None
+    issue_type: str | None = None
+    max_results: int = 5

--- a/memory/service.py
+++ b/memory/service.py
@@ -1,0 +1,157 @@
+"""High-level memory service wrapping the store and extractor modules.
+
+Provides retrieval and storage of cross-session memories for the
+orchestrator.  All store/extractor calls are wrapped in try/except
+so that memory failures never crash the pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+
+from memory.models import MemoryEntry, MemoryQuery, MemoryType
+from memory.store import MemoryStore
+from memory.extractor import extract_memories
+from utils.file_logger import get_logger
+
+logger = get_logger("memory.service")
+
+_MEMORY_TYPE_LABELS: dict[str, str] = {
+    MemoryType.best_practice: "Best Practices",
+    MemoryType.anti_pattern: "Anti-Patterns",
+    MemoryType.heuristic: "Heuristics",
+    MemoryType.execution_note: "Execution Notes",
+    MemoryType.reusable_context: "Reusable Context",
+}
+
+_MAX_PROMPT_CHARS = 2000
+
+
+class MemoryService:
+    """Facade for retrieving and storing pipeline memories."""
+
+    def __init__(
+        self,
+        enabled: bool | None = None,
+        db_path: str | None = None,
+    ) -> None:
+        if enabled is None:
+            enabled = os.getenv("MEMORY_ENABLED", "false").lower() == "true"
+
+        if enabled:
+            self._store: MemoryStore | None = MemoryStore(db_path)
+            logger.info("MemoryService enabled")
+        else:
+            self._store = None
+            logger.info("MemoryService disabled")
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether the memory service is active."""
+        return self._store is not None
+
+    # ------------------------------------------------------------------
+    # Retrieval
+    # ------------------------------------------------------------------
+
+    def retrieve_for_stage(self, stage: str, context: dict) -> str:
+        """Retrieve relevant memories and format as prompt context.
+
+        Returns an empty string when the service is disabled or when no
+        memories match the query.
+        """
+        if not self.enabled:
+            return ""
+
+        try:
+            query_text = (
+                context.get("issue_title", "")
+                + " "
+                + context.get("issue_description", "")
+            ).strip()
+
+            query = MemoryQuery(
+                query_text=query_text,
+                stage=stage,
+                issue_type=context.get("issue_type"),
+                max_results=5,
+            )
+
+            assert self._store is not None  # guarded by self.enabled
+            results = self._store.search(query)
+            return self.format_memories_for_prompt(results)
+        except Exception:
+            logger.exception("Failed to retrieve memories for stage=%s", stage)
+            return ""
+
+    # ------------------------------------------------------------------
+    # Storage
+    # ------------------------------------------------------------------
+
+    def store_from_stage(
+        self,
+        stage: str,
+        context: dict,
+        stage_output: dict,
+    ) -> list[int]:
+        """Extract and store memories from a stage's output.
+
+        Returns the list of stored memory row IDs, or an empty list when
+        the service is disabled or an error occurs.
+        """
+        if not self.enabled:
+            return []
+
+        try:
+            entries = extract_memories(stage, context, stage_output)
+            assert self._store is not None  # guarded by self.enabled
+            ids: list[int] = []
+            for entry in entries:
+                row_id = self._store.store(entry)
+                ids.append(row_id)
+            logger.info(
+                "Stored %d memories from stage=%s", len(ids), stage
+            )
+            return ids
+        except Exception:
+            logger.exception("Failed to store memories for stage=%s", stage)
+            return []
+
+    # ------------------------------------------------------------------
+    # Formatting
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def format_memories_for_prompt(memories: list[MemoryEntry]) -> str:
+        """Format memories as a Markdown section for prompt injection.
+
+        Memories are grouped by ``memory_type`` and the total output is
+        capped at 2000 characters.  Returns an empty string when
+        *memories* is empty.
+        """
+        if not memories:
+            return ""
+
+        grouped: dict[str, list[MemoryEntry]] = {}
+        for mem in memories:
+            label = _MEMORY_TYPE_LABELS.get(mem.memory_type, mem.memory_type)
+            grouped.setdefault(label, []).append(mem)
+
+        lines: list[str] = ["## Cross-Session Memory Context", ""]
+
+        for section_label, entries in grouped.items():
+            lines.append(f"### {section_label}")
+            for entry in entries:
+                lines.append(f"- **{entry.title}**: {entry.content}")
+            lines.append("")
+
+        output = "\n".join(lines).rstrip()
+
+        if len(output) > _MAX_PROMPT_CHARS:
+            output = output[: _MAX_PROMPT_CHARS - 3] + "..."
+
+        return output

--- a/memory/store.py
+++ b/memory/store.py
@@ -1,0 +1,267 @@
+"""SQLite storage layer for persistent cross-session memory.
+
+Provides full-text search (FTS5) over stored memories with BM25 ranking,
+optional filtering by stage, memory type, and issue type, and basic CRUD
+operations scoped to sessions.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+from memory.models import MemoryEntry, MemoryQuery
+from utils.file_logger import get_logger
+
+logger = get_logger("memory.store")
+
+_DEFAULT_DB_PATH = str(
+    Path.home() / ".local" / "share" / "flowpilot" / "memory.db"
+)
+
+
+def _escape_fts5(text: str) -> str:
+    """Quote each token to disable FTS5 operator interpretation."""
+    tokens = text.replace('"', '').split()
+    return " ".join(f'"{t}"' for t in tokens) if tokens else ""
+
+
+class MemoryStore:
+    """SQLite-backed store for pipeline memories with FTS5 search."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = db_path or os.path.expanduser(
+            os.getenv("MEMORY_DB_PATH", _DEFAULT_DB_PATH)
+        )
+        db_dir = os.path.dirname(self.db_path)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+        self._init_schema()
+        logger.info("MemoryStore initialised at %s", self.db_path)
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def _init_schema(self) -> None:
+        """Create the memories table, FTS5 virtual table, and sync triggers."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.cursor()
+
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS memories (
+                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id      TEXT NOT NULL,
+                    stage           TEXT NOT NULL,
+                    memory_type     TEXT NOT NULL,
+                    title           TEXT NOT NULL,
+                    content         TEXT NOT NULL,
+                    tags            TEXT,
+                    issue_title     TEXT,
+                    issue_type      TEXT,
+                    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    relevance_score REAL DEFAULT 1.0
+                )
+            """)
+
+            cursor.execute("""
+                CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+                    title, content, tags,
+                    content='memories',
+                    content_rowid='id'
+                )
+            """)
+
+            # Keep FTS index in sync with the main table.
+            cursor.execute("""
+                CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories
+                BEGIN
+                    INSERT INTO memories_fts(rowid, title, content, tags)
+                    VALUES (new.id, new.title, new.content, new.tags);
+                END
+            """)
+
+            cursor.execute("""
+                CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories
+                BEGIN
+                    INSERT INTO memories_fts(memories_fts, rowid, title, content, tags)
+                    VALUES ('delete', old.id, old.title, old.content, old.tags);
+                END
+            """)
+
+            cursor.execute("""
+                CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories
+                BEGIN
+                    INSERT INTO memories_fts(memories_fts, rowid, title, content, tags)
+                    VALUES ('delete', old.id, old.title, old.content, old.tags);
+                    INSERT INTO memories_fts(rowid, title, content, tags)
+                    VALUES (new.id, new.title, new.content, new.tags);
+                END
+            """)
+
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Connection helper
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a new connection with ``Row`` factory."""
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    # ------------------------------------------------------------------
+    # Row conversion
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_to_entry(row: sqlite3.Row) -> MemoryEntry:
+        """Convert a ``sqlite3.Row`` into a ``MemoryEntry``."""
+        tags_raw: str | None = row["tags"]
+        tags = [t.strip() for t in tags_raw.split(",") if t.strip()] if tags_raw else []
+
+        return MemoryEntry(
+            id=row["id"],
+            session_id=row["session_id"],
+            stage=row["stage"],
+            memory_type=row["memory_type"],
+            title=row["title"],
+            content=row["content"],
+            tags=tags,
+            issue_title=row["issue_title"],
+            issue_type=row["issue_type"],
+            created_at=row["created_at"],
+            relevance_score=row["relevance_score"],
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def store(self, entry: MemoryEntry) -> int:
+        """Persist a ``MemoryEntry`` and return its new row id."""
+        tags_str = ",".join(entry.tags) if entry.tags else None
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO memories
+                    (session_id, stage, memory_type, title, content,
+                     tags, issue_title, issue_type, relevance_score)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.session_id,
+                    entry.stage,
+                    entry.memory_type,
+                    entry.title,
+                    entry.content,
+                    tags_str,
+                    entry.issue_title,
+                    entry.issue_type,
+                    entry.relevance_score,
+                ),
+            )
+            conn.commit()
+            row_id: int = cursor.lastrowid  # type: ignore[assignment]
+            logger.debug("Stored memory id=%d title=%r", row_id, entry.title)
+            return row_id
+        finally:
+            conn.close()
+
+    def search(self, query: MemoryQuery) -> list[MemoryEntry]:
+        """Search memories using FTS5 with BM25 ranking and optional filters.
+
+        When ``query.query_text`` is empty the method falls back to a plain
+        ``SELECT`` on the ``memories`` table with the same optional filters.
+        """
+        conn = self._connect()
+        try:
+            params: list[object] = []
+
+            if query.query_text:
+                # FTS5 path -- join back to memories for filter columns.
+                sql = """
+                    SELECT m.*
+                    FROM memories_fts fts
+                    JOIN memories m ON m.id = fts.rowid
+                    WHERE memories_fts MATCH ?
+                """
+                params.append(_escape_fts5(query.query_text))
+            else:
+                sql = "SELECT * FROM memories WHERE 1=1"
+
+            if query.stage:
+                sql += " AND m.stage = ?" if query.query_text else " AND stage = ?"
+                params.append(query.stage)
+
+            if query.memory_types:
+                placeholders = ",".join("?" * len(query.memory_types))
+                col = "m.memory_type" if query.query_text else "memory_type"
+                sql += f" AND {col} IN ({placeholders})"
+                params.extend(query.memory_types)
+
+            if query.issue_type:
+                sql += " AND m.issue_type = ?" if query.query_text else " AND issue_type = ?"
+                params.append(query.issue_type)
+
+            if query.query_text:
+                sql += " ORDER BY rank"
+            else:
+                sql += " ORDER BY created_at DESC"
+
+            sql += " LIMIT ?"
+            params.append(query.max_results)
+
+            cursor = conn.cursor()
+            cursor.execute(sql, params)
+            return [self._row_to_entry(row) for row in cursor.fetchall()]
+        finally:
+            conn.close()
+
+    def get_by_session(self, session_id: str) -> list[MemoryEntry]:
+        """Return all memories for *session_id* ordered by creation time."""
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM memories WHERE session_id = ? ORDER BY created_at",
+                (session_id,),
+            )
+            return [self._row_to_entry(row) for row in cursor.fetchall()]
+        finally:
+            conn.close()
+
+    def delete_by_session(self, session_id: str) -> int:
+        """Delete all memories for *session_id* and return the number removed."""
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM memories WHERE session_id = ?",
+                (session_id,),
+            )
+            conn.commit()
+            deleted: int = cursor.rowcount
+            logger.info(
+                "Deleted %d memories for session %s", deleted, session_id
+            )
+            return deleted
+        finally:
+            conn.close()
+
+    def count(self) -> int:
+        """Return the total number of stored memories."""
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute("SELECT COUNT(*) FROM memories")
+            return cursor.fetchone()[0]
+        finally:
+            conn.close()

--- a/models/workflow_state.py
+++ b/models/workflow_state.py
@@ -57,6 +57,7 @@ class WorkflowState(TypedDict, total=False):
     session_id: str
     current_phase: str
     approval_status: str
+    memory_context: str
 
     # Repository context
     repo_path: str

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -73,6 +73,7 @@ class WorkflowOrchestrator:
         self._repo_config = self._load_repo_config()
         self._repo_commands = self._extract_repo_commands()
         self._active_stages = self._repo_config.stages
+        self._memory_service = self._init_memory_service()
 
     def _load_repo_config(self) -> "RepoConfig":  # noqa: F821
         """Load the full RepoConfig from repos.yaml.
@@ -102,6 +103,18 @@ class WorkflowOrchestrator:
             if repo.path == self.repo_path:
                 return repo.commands.model_dump(exclude_none=True)
         return None
+
+    def _init_memory_service(self) -> "Optional[MemoryService]":  # noqa: F821
+        """Initialize the memory service if enabled via MEMORY_ENABLED env var."""
+        try:
+            from memory.service import MemoryService
+            service = MemoryService()
+            if service.enabled:
+                from utils.file_logger import get_logger
+                get_logger(__name__).info("Memory service enabled")
+            return service if service.enabled else None
+        except Exception:
+            return None
 
     # -- internal helpers -----------------------------------------------------
 
@@ -189,6 +202,7 @@ class WorkflowOrchestrator:
             repo_path=state.get("repo_path"),
             repo_paths=state.get("repo_paths", []),
             repo_entries=state.get("repo_entries"),
+            memory_context=state.get("memory_context", ""),
         )
 
     def _run_develop(self, state: Dict[str, Any]) -> Dict[str, Any]:
@@ -333,16 +347,26 @@ class WorkflowOrchestrator:
 
         # -- Stage 1: Design --------------------------------------------------
         if self._should_run_stage("design"):
+            if self._memory_service:
+                memory_ctx = self._memory_service.retrieve_for_stage("design", state)
+                if memory_ctx:
+                    state["memory_context"] = memory_ctx
+
             try:
                 result = self._run_design(state)
                 state.update(result)
                 state["current_phase"] = "design_complete"
                 self._emit_heartbeat("design", state)
+                if self._memory_service:
+                    self._memory_service.store_from_stage("design", state, result)
             except Exception as e:
                 state["current_phase"] = "error"
                 state["error"] = f"Design stage failed: {e}"
                 self._emit_heartbeat("design", state)
+                state.pop("memory_context", None)
                 return state
+
+            state.pop("memory_context", None)
 
             if not self._validate("design", state):
                 state["current_phase"] = "error"
@@ -358,8 +382,19 @@ class WorkflowOrchestrator:
 
         # -- Stage 2: Development (with review gate) ----------------------------
         if self._should_run_stage("develop"):
+            if self._memory_service:
+                memory_ctx = self._memory_service.retrieve_for_stage("develop", state)
+                if memory_ctx:
+                    state["memory_context"] = memory_ctx
+
             # _run_develop_with_review_gate mutates *state* in-place.
             self._run_develop_with_review_gate(state)
+
+            if self._memory_service:
+                self._memory_service.store_from_stage("develop", state, state)
+
+            state.pop("memory_context", None)
+
             if state.get("current_phase") == "error":
                 return state
 
@@ -371,16 +406,26 @@ class WorkflowOrchestrator:
 
         # -- Stage 3: Testing --------------------------------------------------
         if self._should_run_stage("testing"):
+            if self._memory_service:
+                memory_ctx = self._memory_service.retrieve_for_stage("testing", state)
+                if memory_ctx:
+                    state["memory_context"] = memory_ctx
+
             try:
                 result = self._run_testing(state)
                 state.update(result)
                 state["current_phase"] = "testing_complete"
                 self._emit_heartbeat("testing", state)
+                if self._memory_service:
+                    self._memory_service.store_from_stage("testing", state, result)
             except Exception as e:
                 state["current_phase"] = "error"
                 state["error"] = f"Testing stage failed: {e}"
                 self._emit_heartbeat("testing", state)
+                state.pop("memory_context", None)
                 return state
+
+            state.pop("memory_context", None)
 
             if not self._validate("testing", state):
                 state["current_phase"] = "error"
@@ -405,16 +450,26 @@ class WorkflowOrchestrator:
 
         # -- Stage 4: Documentation --------------------------------------------
         if self._should_run_stage("docs"):
+            if self._memory_service:
+                memory_ctx = self._memory_service.retrieve_for_stage("docs", state)
+                if memory_ctx:
+                    state["memory_context"] = memory_ctx
+
             try:
                 result = self._run_docs(state)
                 state.update(result)
                 state["current_phase"] = "done"
                 self._emit_heartbeat("docs", state)
+                if self._memory_service:
+                    self._memory_service.store_from_stage("docs", state, result)
             except Exception as e:
                 state["current_phase"] = "error"
                 state["error"] = f"Docs stage failed: {e}"
                 self._emit_heartbeat("docs", state)
+                state.pop("memory_context", None)
                 return state
+
+            state.pop("memory_context", None)
 
             if not self._validate("docs", state):
                 state["current_phase"] = "error"

--- a/stages/design.py
+++ b/stages/design.py
@@ -40,6 +40,7 @@ def run_design(
     repo_path: Optional[str] = None,
     repo_paths: Optional[List[str]] = None,
     repo_entries: Optional[List[dict]] = None,
+    memory_context: str = "",
 ) -> Dict[str, Any]:
     """Run design analysis on a GitHub issue.
 
@@ -112,6 +113,10 @@ def run_design(
         component_context=component_context,
         repo_context=repo_context,
     )
+
+    # Inject cross-session memory context if provided
+    if memory_context:
+        user_prompt += f"\n\n{memory_context}"
 
     # Call Claude API
     try:

--- a/stages/develop.py
+++ b/stages/develop.py
@@ -455,6 +455,11 @@ def _build_development_prompt(
     if review_feedback:
         prompt_parts.append(review_feedback)
 
+    # Inject cross-session memory context if provided
+    memory_context = context.get("memory_context", "")
+    if memory_context:
+        prompt_parts.append(f"\n{memory_context}\n")
+
     # Add code generation instructions
     prompt_parts.append(
         "\n## Code Generation Instructions\n\n"

--- a/stages/docs.py
+++ b/stages/docs.py
@@ -613,6 +613,11 @@ def _build_context_message(
             message_parts.append(f"- {url}\n")
         message_parts.append("\n")
 
+    # Inject cross-session memory context if provided
+    memory_context = context.get("memory_context", "")
+    if memory_context:
+        message_parts.append(f"\n{memory_context}\n")
+
     # Request documentation generation based on format
     message_parts.append("\n---\n\n")
     message_parts.append(_get_generation_request(output_format))

--- a/stages/test.py
+++ b/stages/test.py
@@ -311,6 +311,11 @@ def _build_testing_prompt(
                 f"**Security Contexts:** {', '.join(patterns_detected['security_contexts'])}\n"
             )
 
+    # Inject cross-session memory context if provided
+    memory_context = context.get("memory_context", "")
+    if memory_context:
+        prompt_parts.append(f"\n{memory_context}\n")
+
     # Add test generation instructions
     prompt_parts.append(
         "\n## Test Generation Instructions\n\n"

--- a/tests/test_memory_extractor.py
+++ b/tests/test_memory_extractor.py
@@ -1,0 +1,237 @@
+"""Tests for memory.extractor — rule-based memory extraction from stage outputs."""
+
+from __future__ import annotations
+
+from memory.extractor import extract_memories
+from memory.models import MemoryType
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _base_context(
+    session_id: str = "sess-1",
+    issue_title: str = "Add timeout support",
+    issue_type: str = "feature",
+    impacted_components: list[str] | None = None,
+) -> dict:
+    return {
+        "session_id": session_id,
+        "issue_title": issue_title,
+        "issue_type": issue_type,
+        "impacted_components": impacted_components or ["buildrun_api"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Design extractor
+# ---------------------------------------------------------------------------
+
+class TestExtractDesign:
+    """Design stage extracts reusable_context, heuristic, and best_practice."""
+
+    def test_extract_design_all_fields(self) -> None:
+        context = _base_context()
+        output = {
+            "design_analysis": "Detailed design analysis content here.",
+            "risks": ["Risk of breaking change", "Timeout edge cases"],
+            "implementation_plan": ["Step 1: update API", "Step 2: add tests"],
+        }
+
+        entries = extract_memories("design", context, output)
+
+        # 1 reusable_context (design_analysis)
+        # 2 heuristics (one per risk)
+        # 1 best_practice (implementation plan)
+        assert len(entries) == 4
+
+        types = [e.memory_type for e in entries]
+        assert types.count(MemoryType.reusable_context) == 1
+        assert types.count(MemoryType.heuristic) == 2
+        assert types.count(MemoryType.best_practice) == 1
+
+    def test_extract_design_session_and_tags(self) -> None:
+        context = _base_context(
+            session_id="s-42",
+            impacted_components=["comp-a", "comp-b"],
+        )
+        output = {"design_analysis": "Some analysis"}
+
+        entries = extract_memories("design", context, output)
+        assert len(entries) == 1
+        assert entries[0].session_id == "s-42"
+        assert entries[0].tags == ["comp-a", "comp-b"]
+        assert entries[0].stage == "design"
+
+    def test_extract_design_no_risks_no_plan(self) -> None:
+        output = {"design_analysis": "Just the analysis"}
+        entries = extract_memories("design", _base_context(), output)
+        assert len(entries) == 1
+        assert entries[0].memory_type == MemoryType.reusable_context
+
+
+# ---------------------------------------------------------------------------
+# Develop extractor
+# ---------------------------------------------------------------------------
+
+class TestExtractDevelop:
+    """Develop stage extracts execution_note, anti_pattern, and best_practice."""
+
+    def test_extract_develop_code_files(self) -> None:
+        context = _base_context()
+        output = {
+            "code_files": [{"path": "main.go"}, {"path": "handler.go"}],
+            "test_files": [{"path": "main_test.go"}],
+        }
+
+        entries = extract_memories("develop", context, output)
+        assert len(entries) == 1
+        assert entries[0].memory_type == MemoryType.execution_note
+        assert "main.go" in entries[0].content
+        assert "handler.go" in entries[0].content
+        assert "main_test.go" in entries[0].content
+
+    def test_extract_develop_security_notes(self) -> None:
+        context = _base_context()
+        output = {
+            "code_files": [],
+            "security_notes": "Ensure RBAC is configured properly.",
+        }
+
+        entries = extract_memories("develop", context, output)
+        assert len(entries) == 1
+        assert entries[0].memory_type == MemoryType.best_practice
+        assert "RBAC" in entries[0].content
+
+    def test_extract_develop_review_passed_no_anti_patterns(self) -> None:
+        context = _base_context()
+        output = {
+            "code_files": [],
+            "review_passed": True,
+            "review_findings": ["Minor style issue"],
+        }
+
+        entries = extract_memories("develop", context, output)
+        # review_passed=True -> no anti_pattern entries
+        anti = [e for e in entries if e.memory_type == MemoryType.anti_pattern]
+        assert len(anti) == 0
+
+
+class TestExtractDevelopReviewFailed:
+    """When review_passed=False, anti-pattern entries are created."""
+
+    def test_extract_develop_review_failed(self) -> None:
+        context = _base_context()
+        output = {
+            "code_files": [],
+            "review_passed": False,
+            "review_findings": [
+                "Missing error handling in timeout path",
+                "No unit tests for edge case",
+            ],
+        }
+
+        entries = extract_memories("develop", context, output)
+        anti = [e for e in entries if e.memory_type == MemoryType.anti_pattern]
+        assert len(anti) == 2
+        assert "Missing error handling" in anti[0].content
+
+    def test_extract_develop_review_failed_empty_findings(self) -> None:
+        context = _base_context()
+        output = {
+            "code_files": [],
+            "review_passed": False,
+            "review_findings": [],
+        }
+
+        entries = extract_memories("develop", context, output)
+        anti = [e for e in entries if e.memory_type == MemoryType.anti_pattern]
+        assert len(anti) == 0
+
+
+# ---------------------------------------------------------------------------
+# Testing extractor
+# ---------------------------------------------------------------------------
+
+class TestExtractTesting:
+    """Testing stage extracts reusable_context and heuristic."""
+
+    def test_extract_testing(self) -> None:
+        context = _base_context()
+        output = {
+            "test_plan": "Comprehensive test plan for timeout feature.",
+            "coverage_analysis": "80% line coverage, 65% branch coverage.",
+        }
+
+        entries = extract_memories("testing", context, output)
+        assert len(entries) == 2
+
+        types = {e.memory_type for e in entries}
+        assert MemoryType.reusable_context in types
+        assert MemoryType.heuristic in types
+
+    def test_extract_testing_no_coverage(self) -> None:
+        context = _base_context()
+        output = {"test_plan": "Basic plan"}
+
+        entries = extract_memories("testing", context, output)
+        assert len(entries) == 1
+        assert entries[0].memory_type == MemoryType.reusable_context
+
+    def test_extract_testing_empty_coverage(self) -> None:
+        context = _base_context()
+        output = {"test_plan": "Plan", "coverage_analysis": "   "}
+
+        entries = extract_memories("testing", context, output)
+        # Whitespace-only coverage is treated as empty
+        assert len(entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# Docs extractor
+# ---------------------------------------------------------------------------
+
+class TestExtractDocs:
+    """Docs stage extracts reusable_context from PR summary."""
+
+    def test_extract_docs(self) -> None:
+        context = _base_context()
+        output = {"pr_summary": "Added timeout support to BuildRun API."}
+
+        entries = extract_memories("docs", context, output)
+        assert len(entries) == 1
+        assert entries[0].memory_type == MemoryType.reusable_context
+        assert "timeout" in entries[0].content.lower()
+
+    def test_extract_docs_empty_summary(self) -> None:
+        context = _base_context()
+        output = {"pr_summary": ""}
+
+        entries = extract_memories("docs", context, output)
+        assert len(entries) == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestExtractEdgeCases:
+    """Empty outputs and unknown stages."""
+
+    def test_extract_empty_output(self) -> None:
+        entries = extract_memories("design", _base_context(), {})
+        assert entries == []
+
+    def test_extract_unknown_stage(self) -> None:
+        entries = extract_memories("unknown_stage", _base_context(), {"data": "value"})
+        assert entries == []
+
+    def test_extract_missing_keys(self) -> None:
+        entries = extract_memories("develop", _base_context(), {"unrelated": "field"})
+        assert entries == []
+
+    def test_extract_whitespace_only_content(self) -> None:
+        output = {"design_analysis": "   \n  "}
+        entries = extract_memories("design", _base_context(), output)
+        assert entries == []

--- a/tests/test_memory_models.py
+++ b/tests/test_memory_models.py
@@ -1,0 +1,139 @@
+"""Tests for memory.models — Pydantic models for the persistent memory layer."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from memory.models import VALID_STAGES, MemoryEntry, MemoryQuery, MemoryType
+
+
+class TestMemoryType:
+    """MemoryType enum has all expected values."""
+
+    def test_has_all_five_values(self) -> None:
+        assert len(MemoryType) == 5
+
+    def test_enum_members(self) -> None:
+        expected = {
+            "best_practice",
+            "anti_pattern",
+            "heuristic",
+            "execution_note",
+            "reusable_context",
+        }
+        assert {m.value for m in MemoryType} == expected
+
+    def test_string_values_match_names(self) -> None:
+        for member in MemoryType:
+            assert member.value == member.name
+
+
+class TestMemoryEntry:
+    """MemoryEntry validation and defaults."""
+
+    @pytest.fixture()
+    def valid_entry_kwargs(self) -> dict:
+        """Minimal kwargs that produce a valid MemoryEntry."""
+        return {
+            "session_id": "sess-1",
+            "stage": "design",
+            "memory_type": MemoryType.best_practice,
+            "title": "Example title",
+            "content": "Example content",
+        }
+
+    def test_valid_stages_accepted(self, valid_entry_kwargs: dict) -> None:
+        for stage in VALID_STAGES:
+            entry = MemoryEntry(**{**valid_entry_kwargs, "stage": stage})
+            assert entry.stage == stage
+
+    def test_invalid_stage_raises_validation_error(
+        self, valid_entry_kwargs: dict
+    ) -> None:
+        with pytest.raises(ValidationError, match="stage must be one of"):
+            MemoryEntry(**{**valid_entry_kwargs, "stage": "invalid_stage"})
+
+    def test_default_id_is_none(self, valid_entry_kwargs: dict) -> None:
+        entry = MemoryEntry(**valid_entry_kwargs)
+        assert entry.id is None
+
+    def test_default_tags_is_empty_list(self, valid_entry_kwargs: dict) -> None:
+        entry = MemoryEntry(**valid_entry_kwargs)
+        assert entry.tags == []
+
+    def test_default_relevance_score(self, valid_entry_kwargs: dict) -> None:
+        entry = MemoryEntry(**valid_entry_kwargs)
+        assert entry.relevance_score == 1.0
+
+    def test_default_issue_fields_are_none(self, valid_entry_kwargs: dict) -> None:
+        entry = MemoryEntry(**valid_entry_kwargs)
+        assert entry.issue_title is None
+        assert entry.issue_type is None
+
+    def test_default_created_at_is_none(self, valid_entry_kwargs: dict) -> None:
+        entry = MemoryEntry(**valid_entry_kwargs)
+        assert entry.created_at is None
+
+    def test_tags_assigned_correctly(self, valid_entry_kwargs: dict) -> None:
+        entry = MemoryEntry(**valid_entry_kwargs, tags=["go", "api"])
+        assert entry.tags == ["go", "api"]
+
+    def test_all_fields_set(self) -> None:
+        entry = MemoryEntry(
+            id=42,
+            session_id="sess-2",
+            stage="develop",
+            memory_type=MemoryType.anti_pattern,
+            title="Title",
+            content="Content",
+            tags=["tag1"],
+            issue_title="Issue",
+            issue_type="bug",
+            created_at="2026-01-01T00:00:00",
+            relevance_score=0.8,
+        )
+        assert entry.id == 42
+        assert entry.session_id == "sess-2"
+        assert entry.stage == "develop"
+        assert entry.memory_type == MemoryType.anti_pattern
+        assert entry.issue_type == "bug"
+        assert entry.relevance_score == 0.8
+
+
+class TestMemoryQuery:
+    """MemoryQuery defaults and validation."""
+
+    def test_default_max_results_is_5(self) -> None:
+        query = MemoryQuery(query_text="search term")
+        assert query.max_results == 5
+
+    def test_default_stage_is_none(self) -> None:
+        query = MemoryQuery(query_text="search term")
+        assert query.stage is None
+
+    def test_default_memory_types_is_none(self) -> None:
+        query = MemoryQuery(query_text="search term")
+        assert query.memory_types is None
+
+    def test_default_issue_type_is_none(self) -> None:
+        query = MemoryQuery(query_text="search term")
+        assert query.issue_type is None
+
+    def test_custom_max_results(self) -> None:
+        query = MemoryQuery(query_text="x", max_results=10)
+        assert query.max_results == 10
+
+    def test_all_fields_set(self) -> None:
+        query = MemoryQuery(
+            query_text="timeout",
+            stage="design",
+            memory_types=[MemoryType.best_practice, MemoryType.heuristic],
+            issue_type="feature",
+            max_results=3,
+        )
+        assert query.query_text == "timeout"
+        assert query.stage == "design"
+        assert len(query.memory_types) == 2
+        assert query.issue_type == "feature"
+        assert query.max_results == 3

--- a/tests/test_memory_service.py
+++ b/tests/test_memory_service.py
@@ -1,0 +1,219 @@
+"""Tests for memory.service — high-level MemoryService facade."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memory.models import MemoryEntry, MemoryType
+from memory.service import MemoryService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def enabled_service(tmp_path: Path) -> MemoryService:
+    """Return a MemoryService that is explicitly enabled with a temp DB."""
+    return MemoryService(enabled=True, db_path=str(tmp_path / "svc.db"))
+
+
+def _sample_entry(
+    session_id: str = "sess-1",
+    stage: str = "design",
+    memory_type: MemoryType = MemoryType.best_practice,
+    title: str = "Sample title",
+    content: str = "Sample content",
+) -> MemoryEntry:
+    return MemoryEntry(
+        session_id=session_id,
+        stage=stage,
+        memory_type=memory_type,
+        title=title,
+        content=content,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enabled / disabled lifecycle
+# ---------------------------------------------------------------------------
+
+class TestEnabledDisabledLifecycle:
+    """MemoryService respects MEMORY_ENABLED env var and explicit flag."""
+
+    def test_disabled_by_default(self) -> None:
+        svc = MemoryService()
+        assert svc.enabled is False
+
+    def test_enabled_via_env(self, monkeypatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_DB_PATH", str(tmp_path / "env.db"))
+        svc = MemoryService()
+        assert svc.enabled is True
+
+    def test_enabled_via_explicit_flag(self, tmp_path: Path) -> None:
+        svc = MemoryService(enabled=True, db_path=str(tmp_path / "flag.db"))
+        assert svc.enabled is True
+
+    def test_disabled_via_explicit_flag(self, tmp_path: Path) -> None:
+        svc = MemoryService(enabled=False, db_path=str(tmp_path / "off.db"))
+        assert svc.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Disabled behaviour
+# ---------------------------------------------------------------------------
+
+class TestDisabledBehaviour:
+    """When disabled, retrieve and store are safe no-ops."""
+
+    def test_retrieve_when_disabled(self) -> None:
+        svc = MemoryService(enabled=False)
+        result = svc.retrieve_for_stage("design", {"issue_title": "test"})
+        assert result == ""
+
+    def test_store_when_disabled(self) -> None:
+        svc = MemoryService(enabled=False)
+        ids = svc.store_from_stage("design", {"session_id": "s1"}, {"design_analysis": "x"})
+        assert ids == []
+
+
+# ---------------------------------------------------------------------------
+# Retrieval
+# ---------------------------------------------------------------------------
+
+class TestRetrieveForStage:
+    """retrieve_for_stage searches and formats memories."""
+
+    def test_retrieve_for_stage_with_stored_memories(
+        self, enabled_service: MemoryService
+    ) -> None:
+        # Store an entry directly through the underlying store
+        assert enabled_service._store is not None
+        enabled_service._store.store(
+            _sample_entry(
+                stage="design",
+                title="Prior design",
+                content="Build timeout logic for BuildRun controller",
+            )
+        )
+
+        result = enabled_service.retrieve_for_stage(
+            "design",
+            {"issue_title": "timeout", "issue_description": "build timeout"},
+        )
+        assert "Prior design" in result
+        assert "Cross-Session Memory Context" in result
+
+    def test_retrieve_for_stage_no_matches(
+        self, enabled_service: MemoryService
+    ) -> None:
+        result = enabled_service.retrieve_for_stage(
+            "design",
+            {"issue_title": "something", "issue_description": "else"},
+        )
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+class TestStoreFromStage:
+    """store_from_stage extracts and persists memories."""
+
+    def test_store_from_stage_returns_ids(
+        self, enabled_service: MemoryService
+    ) -> None:
+        context = {
+            "session_id": "s-1",
+            "issue_title": "Timeout",
+            "issue_type": "feature",
+        }
+        output = {
+            "design_analysis": "Detailed analysis of timeout feature.",
+            "risks": ["Breaking API change"],
+            "implementation_plan": ["Update types", "Add tests"],
+        }
+
+        ids = enabled_service.store_from_stage("design", context, output)
+        # design extractor: 1 reusable_context + 1 heuristic + 1 best_practice = 3
+        assert len(ids) == 3
+        assert all(isinstance(i, int) for i in ids)
+
+    def test_store_from_stage_empty_output(
+        self, enabled_service: MemoryService
+    ) -> None:
+        ids = enabled_service.store_from_stage(
+            "design", {"session_id": "s-1"}, {}
+        )
+        assert ids == []
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+class TestFormatMemoriesForPrompt:
+    """format_memories_for_prompt groups and formats memories."""
+
+    def test_format_memories_for_prompt(self) -> None:
+        memories = [
+            _sample_entry(
+                memory_type=MemoryType.best_practice,
+                title="Practice A",
+                content="Content A",
+            ),
+            _sample_entry(
+                memory_type=MemoryType.heuristic,
+                title="Heuristic B",
+                content="Content B",
+            ),
+            _sample_entry(
+                memory_type=MemoryType.best_practice,
+                title="Practice C",
+                content="Content C",
+            ),
+        ]
+
+        result = MemoryService.format_memories_for_prompt(memories)
+        assert "## Cross-Session Memory Context" in result
+        assert "### Best Practices" in result
+        assert "### Heuristics" in result
+        assert "**Practice A**" in result
+        assert "**Practice C**" in result
+        assert "**Heuristic B**" in result
+
+    def test_format_empty_memories(self) -> None:
+        result = MemoryService.format_memories_for_prompt([])
+        assert result == ""
+
+    def test_format_truncates_at_2000_chars(self) -> None:
+        # Create entries with enough content to exceed 2000 chars
+        memories = [
+            _sample_entry(
+                memory_type=MemoryType.best_practice,
+                title=f"Title {i}",
+                content="X" * 300,
+            )
+            for i in range(20)
+        ]
+
+        result = MemoryService.format_memories_for_prompt(memories)
+        assert len(result) <= 2000
+        assert result.endswith("...")
+
+    def test_format_single_memory(self) -> None:
+        memories = [
+            _sample_entry(
+                memory_type=MemoryType.execution_note,
+                title="Note",
+                content="Detail",
+            )
+        ]
+
+        result = MemoryService.format_memories_for_prompt(memories)
+        assert "### Execution Notes" in result
+        assert "**Note**: Detail" in result

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,0 +1,258 @@
+"""Tests for memory.store — SQLite + FTS5 storage layer."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from memory.models import MemoryEntry, MemoryQuery, MemoryType
+from memory.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def store(tmp_path: Path) -> MemoryStore:
+    """Return a MemoryStore backed by a temp-dir SQLite database."""
+    return MemoryStore(db_path=str(tmp_path / "test_memory.db"))
+
+
+def _make_entry(
+    session_id: str = "sess-1",
+    stage: str = "design",
+    memory_type: MemoryType = MemoryType.best_practice,
+    title: str = "Test title",
+    content: str = "Test content",
+    tags: list[str] | None = None,
+    issue_title: str | None = None,
+    issue_type: str | None = None,
+) -> MemoryEntry:
+    return MemoryEntry(
+        session_id=session_id,
+        stage=stage,
+        memory_type=memory_type,
+        title=title,
+        content=content,
+        tags=tags or [],
+        issue_title=issue_title,
+        issue_type=issue_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    """Database and schema creation."""
+
+    def test_init_creates_db(self, tmp_path: Path) -> None:
+        db_path = str(tmp_path / "init_test.db")
+        MemoryStore(db_path=db_path)
+        assert Path(db_path).exists()
+
+    def test_init_creates_tables(self, tmp_path: Path) -> None:
+        db_path = str(tmp_path / "tables_test.db")
+        MemoryStore(db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        tables = {row[0] for row in cursor.fetchall()}
+        conn.close()
+
+        assert "memories" in tables
+        # FTS5 virtual tables create multiple shadow tables; the main one:
+        assert "memories_fts" in tables
+
+    def test_init_creates_parent_dirs(self, tmp_path: Path) -> None:
+        db_path = str(tmp_path / "sub" / "dir" / "deep.db")
+        MemoryStore(db_path=db_path)
+        assert Path(db_path).exists()
+
+
+class TestStoreAndRetrieve:
+    """store() + get_by_session() round-trip."""
+
+    def test_store_and_retrieve(self, store: MemoryStore) -> None:
+        entry = _make_entry(title="Alpha", content="First memory")
+        row_id = store.store(entry)
+        assert isinstance(row_id, int)
+        assert row_id > 0
+
+        results = store.get_by_session("sess-1")
+        assert len(results) == 1
+        assert results[0].title == "Alpha"
+        assert results[0].content == "First memory"
+        assert results[0].id == row_id
+
+    def test_store_multiple_sessions(self, store: MemoryStore) -> None:
+        store.store(_make_entry(session_id="a", title="A"))
+        store.store(_make_entry(session_id="b", title="B"))
+
+        assert len(store.get_by_session("a")) == 1
+        assert len(store.get_by_session("b")) == 1
+        assert len(store.get_by_session("c")) == 0
+
+
+class TestSearchFTS:
+    """Full-text search with BM25 ranking."""
+
+    def test_search_fts_returns_relevant(self, store: MemoryStore) -> None:
+        store.store(_make_entry(title="Timeout handling", content="Build timeout logic for BuildRun"))
+        store.store(_make_entry(title="Webhook setup", content="Configure admission webhooks"))
+        store.store(_make_entry(title="Timeout validation", content="Validate timeout field values"))
+
+        query = MemoryQuery(query_text="timeout", max_results=10)
+        results = store.search(query)
+
+        # Both timeout entries should appear; webhook should not
+        titles = [r.title for r in results]
+        assert "Timeout handling" in titles
+        assert "Timeout validation" in titles
+        assert "Webhook setup" not in titles
+
+    def test_search_fts_respects_max_results(self, store: MemoryStore) -> None:
+        for i in range(10):
+            store.store(_make_entry(title=f"Timeout item {i}", content="timeout content"))
+
+        query = MemoryQuery(query_text="timeout", max_results=3)
+        results = store.search(query)
+        assert len(results) == 3
+
+
+class TestSearchWithFilters:
+    """Filtered search by stage, memory_type, and issue_type."""
+
+    def test_filter_by_stage(self, store: MemoryStore) -> None:
+        store.store(_make_entry(stage="design", title="Design note", content="design data"))
+        store.store(_make_entry(stage="develop", title="Dev note", content="develop data"))
+
+        query = MemoryQuery(query_text="note", stage="design", max_results=10)
+        results = store.search(query)
+        assert len(results) == 1
+        assert results[0].stage == "design"
+
+    def test_filter_by_memory_type(self, store: MemoryStore) -> None:
+        store.store(
+            _make_entry(
+                memory_type=MemoryType.best_practice,
+                title="Best practice",
+                content="practice detail",
+            )
+        )
+        store.store(
+            _make_entry(
+                memory_type=MemoryType.anti_pattern,
+                title="Anti-pattern",
+                content="pattern detail",
+            )
+        )
+
+        query = MemoryQuery(
+            query_text="detail",
+            memory_types=[MemoryType.anti_pattern],
+            max_results=10,
+        )
+        results = store.search(query)
+        assert len(results) == 1
+        assert results[0].memory_type == MemoryType.anti_pattern
+
+    def test_filter_by_issue_type(self, store: MemoryStore) -> None:
+        store.store(_make_entry(issue_type="feature", title="Feature entry", content="feature info"))
+        store.store(_make_entry(issue_type="bug", title="Bug entry", content="bug info"))
+
+        query = MemoryQuery(query_text="entry", issue_type="bug", max_results=10)
+        results = store.search(query)
+        assert len(results) == 1
+        assert results[0].issue_type == "bug"
+
+
+class TestSearchEmptyQuery:
+    """Empty query_text falls back to regular SELECT."""
+
+    def test_search_empty_query(self, store: MemoryStore) -> None:
+        store.store(_make_entry(title="Alpha", content="First"))
+        store.store(_make_entry(title="Beta", content="Second"))
+
+        query = MemoryQuery(query_text="", max_results=10)
+        results = store.search(query)
+        assert len(results) == 2
+
+    def test_search_empty_query_with_stage_filter(self, store: MemoryStore) -> None:
+        store.store(_make_entry(stage="design", title="D1", content="design stuff"))
+        store.store(_make_entry(stage="testing", title="T1", content="testing stuff"))
+
+        query = MemoryQuery(query_text="", stage="testing", max_results=10)
+        results = store.search(query)
+        assert len(results) == 1
+        assert results[0].stage == "testing"
+
+
+class TestDelete:
+    """delete_by_session removes entries and returns count."""
+
+    def test_delete_by_session(self, store: MemoryStore) -> None:
+        store.store(_make_entry(session_id="del-sess", title="A"))
+        store.store(_make_entry(session_id="del-sess", title="B"))
+        store.store(_make_entry(session_id="keep-sess", title="C"))
+
+        deleted = store.delete_by_session("del-sess")
+        assert deleted == 2
+        assert len(store.get_by_session("del-sess")) == 0
+        assert len(store.get_by_session("keep-sess")) == 1
+
+    def test_delete_nonexistent_session_returns_zero(self, store: MemoryStore) -> None:
+        deleted = store.delete_by_session("no-such-session")
+        assert deleted == 0
+
+
+class TestCount:
+    """count() returns the total number of stored memories."""
+
+    def test_count_empty(self, store: MemoryStore) -> None:
+        assert store.count() == 0
+
+    def test_count_after_inserts(self, store: MemoryStore) -> None:
+        store.store(_make_entry(title="One"))
+        store.store(_make_entry(title="Two"))
+        store.store(_make_entry(title="Three"))
+        assert store.count() == 3
+
+    def test_count_after_delete(self, store: MemoryStore) -> None:
+        store.store(_make_entry(session_id="s1", title="One"))
+        store.store(_make_entry(session_id="s1", title="Two"))
+        store.delete_by_session("s1")
+        assert store.count() == 0
+
+
+class TestTagsRoundTrip:
+    """Tags stored as comma-separated string, retrieved as list."""
+
+    def test_tags_roundtrip(self, store: MemoryStore) -> None:
+        entry = _make_entry(tags=["buildrun", "controller", "api"])
+        store.store(entry)
+
+        results = store.get_by_session("sess-1")
+        assert len(results) == 1
+        assert results[0].tags == ["buildrun", "controller", "api"]
+
+    def test_empty_tags_roundtrip(self, store: MemoryStore) -> None:
+        entry = _make_entry(tags=[])
+        store.store(entry)
+
+        results = store.get_by_session("sess-1")
+        assert results[0].tags == []
+
+    def test_single_tag_roundtrip(self, store: MemoryStore) -> None:
+        entry = _make_entry(tags=["single"])
+        store.store(entry)
+
+        results = store.get_by_session("sess-1")
+        assert results[0].tags == ["single"]

--- a/tests/test_workflow_memory.py
+++ b/tests/test_workflow_memory.py
@@ -1,0 +1,276 @@
+"""Integration tests for memory in the WorkflowOrchestrator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from orchestrator.workflow import WorkflowOrchestrator
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def orchestrator(tmp_path: Path) -> WorkflowOrchestrator:
+    """Return a WorkflowOrchestrator with memory disabled (default)."""
+    return WorkflowOrchestrator(
+        session_id="test-session",
+        repo_path="/tmp/fake-repo",
+        output_dir=tmp_path,
+    )
+
+
+# Patch targets
+_HEARTBEAT_PATCH = "orchestrator.workflow.WorkflowOrchestrator._emit_heartbeat"
+_VALIDATE_PATCH = "orchestrator.workflow.WorkflowOrchestrator._validate"
+_DESIGN_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_design"
+_DEVELOP_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_develop"
+_REVIEW_GATE_PATCH = "orchestrator.gates.run_review_gate"
+_TESTING_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_testing"
+_DOCS_PATCH = "orchestrator.workflow.WorkflowOrchestrator._run_docs"
+
+
+def _design_result() -> dict:
+    return {
+        "design_analysis": "A" * 100,
+        "impacted_components": ["comp-a"],
+        "risks": ["risk-a"],
+        "acceptance_criteria": ["ac-1"],
+        "implementation_plan": ["step-1", "step-2"],
+    }
+
+
+def _develop_result() -> dict:
+    return {
+        "code_files": [{"path": "main.go", "content": "package main"}],
+        "test_files": [],
+        "code_changes": {},
+        "files_modified": ["main.go"],
+        "pr_description": "Added main.go with core logic.",
+    }
+
+
+def _review_pass_result() -> dict:
+    return {
+        "review_passed": True,
+        "review_findings": [],
+        "review_summary": "All good",
+        "review_iteration": 1,
+    }
+
+
+def _testing_result() -> dict:
+    return {
+        "test_plan": "A" * 50,
+        "test_specifications": {},
+        "unit_tests": {"main_test.go": "package main"},
+        "integration_tests": {},
+        "e2e_tests": {},
+        "test_summary": "All tests pass",
+        "coverage_analysis": "80%",
+    }
+
+
+def _docs_result() -> dict:
+    return {
+        "pr_summary": "A" * 50,
+        "release_notes": "Release v1.0",
+        "docs_changes": {},
+    }
+
+
+def _run_kwargs() -> dict:
+    return {"title": "Test feature", "description": "A test description"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: MemoryService lifecycle in the orchestrator
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorMemoryInit:
+    """Memory service initialisation inside WorkflowOrchestrator."""
+
+    def test_orchestrator_no_memory_by_default(
+        self, orchestrator: WorkflowOrchestrator
+    ) -> None:
+        """Default env has MEMORY_ENABLED unset, so _memory_service is None."""
+        assert orchestrator._memory_service is None
+
+    def test_orchestrator_creates_memory_service(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """When MEMORY_ENABLED=true, orchestrator creates a MemoryService."""
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_DB_PATH", str(tmp_path / "orch.db"))
+
+        orch = WorkflowOrchestrator(
+            session_id="mem-test",
+            repo_path="/tmp/fake-repo",
+            output_dir=tmp_path,
+        )
+        assert orch._memory_service is not None
+        assert orch._memory_service.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: Memory context injection into state
+# ---------------------------------------------------------------------------
+
+class TestMemoryContextInjection:
+    """Memory context is injected before stage calls and removed after."""
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    @patch(_VALIDATE_PATCH, return_value=True)
+    @patch(_DOCS_PATCH)
+    @patch(_TESTING_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
+    @patch(_DEVELOP_PATCH)
+    @patch(_DESIGN_PATCH)
+    def test_memory_context_injected_into_state(
+        self,
+        mock_design: MagicMock,
+        mock_develop: MagicMock,
+        mock_review_gate: MagicMock,
+        mock_testing: MagicMock,
+        mock_docs: MagicMock,
+        mock_validate: MagicMock,
+        mock_heartbeat: MagicMock,
+        monkeypatch,
+        tmp_path: Path,
+    ) -> None:
+        """When memory is enabled, retrieve_for_stage output appears in state
+        before _run_design is called, and is cleaned up afterwards."""
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_DB_PATH", str(tmp_path / "inject.db"))
+
+        orch = WorkflowOrchestrator(
+            session_id="inject-test",
+            repo_path="/tmp/fake-repo",
+            output_dir=tmp_path,
+        )
+
+        memory_text = "## Cross-Session Memory Context\n\n### Best Practices\n- **Tip**: Do X"
+        with patch.object(
+            orch._memory_service, "retrieve_for_stage", return_value=memory_text
+        ) as mock_retrieve:
+            # Capture the state dict passed to _run_design
+            captured_states: list[dict] = []
+
+            def capture_design(state: dict) -> dict:
+                captured_states.append(dict(state))
+                return _design_result()
+
+            mock_design.side_effect = capture_design
+            mock_develop.return_value = _develop_result()
+            mock_review_gate.return_value = _review_pass_result()
+            mock_testing.return_value = _testing_result()
+            mock_docs.return_value = _docs_result()
+
+            # Also patch store_from_stage so it doesn't error
+            with patch.object(orch._memory_service, "store_from_stage", return_value=[]):
+                state = orch.run(**_run_kwargs())
+
+            assert state["current_phase"] == "done"
+            # retrieve_for_stage should have been called for each stage
+            assert mock_retrieve.call_count == 4
+
+            # The state passed to _run_design should have had memory_context
+            assert len(captured_states) == 1
+            assert captured_states[0]["memory_context"] == memory_text
+
+            # After the run, memory_context should be cleaned up
+            assert "memory_context" not in state
+
+
+# ---------------------------------------------------------------------------
+# Tests: Memory stored after each stage
+# ---------------------------------------------------------------------------
+
+class TestMemoryStoredAfterStage:
+    """store_from_stage is called after each successful stage."""
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    @patch(_VALIDATE_PATCH, return_value=True)
+    @patch(_DOCS_PATCH)
+    @patch(_TESTING_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
+    @patch(_DEVELOP_PATCH)
+    @patch(_DESIGN_PATCH)
+    def test_memory_stored_after_stage(
+        self,
+        mock_design: MagicMock,
+        mock_develop: MagicMock,
+        mock_review_gate: MagicMock,
+        mock_testing: MagicMock,
+        mock_docs: MagicMock,
+        mock_validate: MagicMock,
+        mock_heartbeat: MagicMock,
+        monkeypatch,
+        tmp_path: Path,
+    ) -> None:
+        """store_from_stage is called once per stage after successful execution."""
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_DB_PATH", str(tmp_path / "store.db"))
+
+        orch = WorkflowOrchestrator(
+            session_id="store-test",
+            repo_path="/tmp/fake-repo",
+            output_dir=tmp_path,
+        )
+
+        mock_design.return_value = _design_result()
+        mock_develop.return_value = _develop_result()
+        mock_review_gate.return_value = _review_pass_result()
+        mock_testing.return_value = _testing_result()
+        mock_docs.return_value = _docs_result()
+
+        with patch.object(
+            orch._memory_service, "retrieve_for_stage", return_value=""
+        ), patch.object(
+            orch._memory_service, "store_from_stage", return_value=[]
+        ) as mock_store:
+            state = orch.run(**_run_kwargs())
+
+        assert state["current_phase"] == "done"
+
+        # store_from_stage called for design, develop, testing, docs = 4
+        assert mock_store.call_count == 4
+
+        # Verify the stage names passed to store_from_stage
+        stage_names = [call.args[0] for call in mock_store.call_args_list]
+        assert stage_names == ["design", "develop", "testing", "docs"]
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    @patch(_VALIDATE_PATCH, return_value=True)
+    @patch(_DESIGN_PATCH, side_effect=RuntimeError("boom"))
+    def test_memory_not_stored_on_stage_failure(
+        self,
+        mock_design: MagicMock,
+        mock_validate: MagicMock,
+        mock_heartbeat: MagicMock,
+        monkeypatch,
+        tmp_path: Path,
+    ) -> None:
+        """When a stage fails, store_from_stage is NOT called for it."""
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        monkeypatch.setenv("MEMORY_DB_PATH", str(tmp_path / "nofail.db"))
+
+        orch = WorkflowOrchestrator(
+            session_id="fail-test",
+            repo_path="/tmp/fake-repo",
+            output_dir=tmp_path,
+        )
+
+        with patch.object(
+            orch._memory_service, "retrieve_for_stage", return_value=""
+        ), patch.object(
+            orch._memory_service, "store_from_stage", return_value=[]
+        ) as mock_store:
+            state = orch.run(**_run_kwargs())
+
+        assert state["current_phase"] == "error"
+        mock_store.assert_not_called()


### PR DESCRIPTION
Closes #90

## Summary
- Add `memory/` module with SQLite + FTS5 storage for cross-session agent learning
- Agents retrieve relevant past decisions (best practices, anti-patterns, heuristics) before each pipeline stage and store lessons learned after execution
- Rule-based memory extraction from stage outputs — no additional API calls
- Integrates into all 4 stages: Design, Develop, Testing, Docs
- Disabled by default (`MEMORY_ENABLED=false`), stored at `~/.local/share/flowpilot/memory.db`

## New files
- `memory/models.py` — MemoryType enum, MemoryEntry/MemoryQuery Pydantic models
- `memory/store.py` — SQLite + FTS5 storage with BM25 search ranking
- `memory/service.py` — High-level service (retrieve before stage, store after)
- `memory/extractor.py` — Rule-based extraction from stage outputs

## Modified files
- `orchestrator/workflow.py` — Memory retrieval/storage around each stage
- `stages/design.py`, `develop.py`, `test.py`, `docs.py` — Memory context injection into prompts
- `models/workflow_state.py` — Added `memory_context` field
- `.env.example`, `CLAUDE.md` — Configuration documentation

## Test plan
- [x] 74 new tests across 5 test files (models, store, extractor, service, workflow integration)
- [x] Full suite: 882 passed, 0 failed, 4 skipped
- [x] Code review: 2 critical findings fixed (design stage passthrough, FTS5 query escaping)
- [x] Memory disabled by default — zero impact on existing pipelines