### PR TITLE
feat: smart stage skipping based on pipeline output (#145)

### DIFF
--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -192,6 +192,26 @@ class WorkflowOrchestrator:
             return _prompt_approval(phase, next_phase)
         return True
 
+    def _should_skip_testing(self, state: Dict[str, Any]) -> str:
+        """Check if the testing stage should be skipped.
+
+        Returns a reason string if testing should be skipped, or empty string if not.
+        """
+        if state.get("issue_type") == "docs":
+            return "docs-only task"
+        if not state.get("code_files"):
+            return "no code files produced"
+        return ""
+
+    def _should_skip_develop(self, state: Dict[str, Any]) -> str:
+        """Check if the develop stage should be skipped.
+
+        Returns a reason string if develop should be skipped, or empty string if not.
+        """
+        if state.get("issue_type") == "docs":
+            return "docs-only task"
+        return ""
+
     # -- stage runners (deferred imports to avoid circular deps) ---------------
 
     def _run_design(self, state: Dict[str, Any]) -> Dict[str, Any]:
@@ -319,7 +339,7 @@ class WorkflowOrchestrator:
         Args:
             title: Issue / feature title.
             description: Issue / feature description.
-            issue_type: One of ``"feature"``, ``"bug"``, ``"refactor"``.
+            issue_type: One of ``"feature"``, ``"bug"``, ``"refactor"``, ``"docs"``.
             extra_state: Optional additional fields to merge into the
                 initial pipeline state (e.g. Jira enrichment data).
 
@@ -381,7 +401,8 @@ class WorkflowOrchestrator:
             self._emit_heartbeat("design", {**state, "skipped": True})
 
         # -- Stage 2: Development (with review gate) ----------------------------
-        if self._should_run_stage("develop"):
+        skip_develop_reason = self._should_skip_develop(state)
+        if self._should_run_stage("develop") and not skip_develop_reason:
             if self._memory_service:
                 memory_ctx = self._memory_service.retrieve_for_stage("develop", state)
                 if memory_ctx:
@@ -402,10 +423,14 @@ class WorkflowOrchestrator:
             if not self._check_approval("develop", "testing"):
                 return state
         else:
-            self._emit_heartbeat("develop", {**state, "skipped": True})
+            reason = skip_develop_reason or "excluded in repos.yaml"
+            from utils.file_logger import get_logger
+            get_logger(__name__).info("Skipping develop stage: %s", reason)
+            self._emit_heartbeat("develop", {**state, "skipped": True, "skip_reason": reason})
 
         # -- Stage 3: Testing --------------------------------------------------
-        if self._should_run_stage("testing"):
+        skip_testing_reason = self._should_skip_testing(state)
+        if self._should_run_stage("testing") and not skip_testing_reason:
             if self._memory_service:
                 memory_ctx = self._memory_service.retrieve_for_stage("testing", state)
                 if memory_ctx:
@@ -446,7 +471,10 @@ class WorkflowOrchestrator:
             if not self._check_approval("testing", "docs"):
                 return state
         else:
-            self._emit_heartbeat("testing", {**state, "skipped": True})
+            reason = skip_testing_reason or "excluded in repos.yaml"
+            from utils.file_logger import get_logger
+            get_logger(__name__).info("Skipping testing stage: %s", reason)
+            self._emit_heartbeat("testing", {**state, "skipped": True, "skip_reason": reason})
 
         # -- Stage 4: Documentation --------------------------------------------
         if self._should_run_stage("docs"):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -937,3 +937,139 @@ class TestPauseSignal:
         assert "Pause timeout" in state["error"]
         # Pause file should be cleaned up on timeout
         assert not pause_file.exists()
+
+
+class TestSmartStageSkipping:
+    """Smart skip logic based on issue_type and code_files content."""
+
+    # -- _should_skip_testing unit tests --------------------------------------
+
+    def test_should_skip_testing_no_code_files(
+        self, orchestrator: WorkflowOrchestrator
+    ) -> None:
+        """_should_skip_testing returns 'no code files produced' when code_files is empty or missing."""
+        # Missing key
+        assert orchestrator._should_skip_testing({}) == "no code files produced"
+        # Empty list
+        assert orchestrator._should_skip_testing({"code_files": []}) == "no code files produced"
+        # Explicitly None
+        assert orchestrator._should_skip_testing({"code_files": None}) == "no code files produced"
+
+    def test_should_skip_testing_with_code_files(
+        self, orchestrator: WorkflowOrchestrator
+    ) -> None:
+        """_should_skip_testing returns empty string when code_files has items."""
+        state = {"code_files": [{"path": "main.go", "content": "package main"}]}
+        assert orchestrator._should_skip_testing(state) == ""
+
+    def test_should_skip_testing_docs_type(
+        self, orchestrator: WorkflowOrchestrator
+    ) -> None:
+        """_should_skip_testing returns 'docs-only task' when issue_type is 'docs'."""
+        state = {"issue_type": "docs", "code_files": [{"path": "f.go", "content": "x"}]}
+        assert orchestrator._should_skip_testing(state) == "docs-only task"
+
+    # -- _should_skip_develop unit tests --------------------------------------
+
+    def test_should_skip_develop_docs_type(
+        self, orchestrator: WorkflowOrchestrator
+    ) -> None:
+        """_should_skip_develop returns 'docs-only task' when issue_type is 'docs'."""
+        assert orchestrator._should_skip_develop({"issue_type": "docs"}) == "docs-only task"
+
+    def test_should_skip_develop_feature_type(
+        self, orchestrator: WorkflowOrchestrator
+    ) -> None:
+        """_should_skip_develop returns empty string for issue_type 'feature'."""
+        assert orchestrator._should_skip_develop({"issue_type": "feature"}) == ""
+
+    # -- full pipeline integration tests --------------------------------------
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    @patch(_VALIDATE_PATCH, return_value=True)
+    @patch(_DOCS_PATCH)
+    @patch(_TESTING_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
+    @patch(_DEVELOP_PATCH)
+    @patch(_DESIGN_PATCH)
+    def test_run_skips_testing_when_no_code_files(
+        self,
+        mock_design: MagicMock,
+        mock_develop: MagicMock,
+        mock_review_gate: MagicMock,
+        mock_testing: MagicMock,
+        mock_docs: MagicMock,
+        mock_validate: MagicMock,
+        mock_heartbeat: MagicMock,
+        orchestrator: WorkflowOrchestrator,
+    ) -> None:
+        """When develop produces no code_files, testing stage is NOT called."""
+        mock_design.return_value = _design_result()
+        # Develop returns empty code_files
+        develop_result = _develop_result()
+        develop_result["code_files"] = []
+        mock_develop.return_value = develop_result
+        mock_review_gate.return_value = _review_pass_result()
+        mock_docs.return_value = _docs_result()
+
+        state = orchestrator.run(**_run_kwargs())
+
+        assert state["current_phase"] == "done"
+        mock_design.assert_called_once()
+        mock_develop.assert_called_once()
+        mock_review_gate.assert_called_once()
+        mock_testing.assert_not_called()
+        mock_docs.assert_called_once()
+
+        # Verify testing heartbeat was emitted with skipped=True and skip_reason
+        hb_calls = [(c.args[0], c.args[1]) for c in mock_heartbeat.call_args_list]
+        testing_hb = [s for agent, s in hb_calls if agent == "testing"]
+        assert len(testing_hb) == 1
+        assert testing_hb[0].get("skipped") is True
+        assert testing_hb[0].get("skip_reason") == "no code files produced"
+
+    @patch(_HEARTBEAT_PATCH, return_value=True)
+    @patch(_VALIDATE_PATCH, return_value=True)
+    @patch(_DOCS_PATCH)
+    @patch(_TESTING_PATCH)
+    @patch(_REVIEW_GATE_PATCH)
+    @patch(_DEVELOP_PATCH)
+    @patch(_DESIGN_PATCH)
+    def test_run_skips_develop_and_testing_for_docs(
+        self,
+        mock_design: MagicMock,
+        mock_develop: MagicMock,
+        mock_review_gate: MagicMock,
+        mock_testing: MagicMock,
+        mock_docs: MagicMock,
+        mock_validate: MagicMock,
+        mock_heartbeat: MagicMock,
+        orchestrator: WorkflowOrchestrator,
+    ) -> None:
+        """When issue_type='docs', develop and testing are NOT called but design and docs ARE."""
+        mock_design.return_value = _design_result()
+        mock_docs.return_value = _docs_result()
+
+        state = orchestrator.run(
+            title="Update README",
+            description="Add installation instructions",
+            issue_type="docs",
+        )
+
+        assert state["current_phase"] == "done"
+        mock_design.assert_called_once()
+        mock_develop.assert_not_called()
+        mock_review_gate.assert_not_called()
+        mock_testing.assert_not_called()
+        mock_docs.assert_called_once()
+
+        # Verify both develop and testing heartbeats were emitted with skipped=True
+        hb_calls = [(c.args[0], c.args[1]) for c in mock_heartbeat.call_args_list]
+        develop_hb = [s for agent, s in hb_calls if agent == "develop"]
+        testing_hb = [s for agent, s in hb_calls if agent == "testing"]
+        assert len(develop_hb) == 1
+        assert develop_hb[0].get("skipped") is True
+        assert develop_hb[0].get("skip_reason") == "docs-only task"
+        assert len(testing_hb) == 1
+        assert testing_hb[0].get("skipped") is True
+        assert testing_hb[0].get("skip_reason") == "docs-only task"


### PR DESCRIPTION
Closes #145

## Summary
- Skip testing stage when develop produces no `code_files` (e.g., docs-only tasks that generate documentation instead of code)
- Skip develop + testing entirely when `issue_type="docs"` — go straight from design to docs
- Log skip reason and include `skip_reason` in dashboard heartbeat for visibility

## Changes
- `orchestrator/workflow.py` — added `_should_skip_testing()` and `_should_skip_develop()` helper methods, integrated into `run()`
- `tests/test_workflow.py` — 7 new tests in `TestSmartStageSkipping` class

## Test plan
- [x] 889 passed, 0 failed, 4 skipped
- [x] Unit tests for both skip predicates (empty/None/missing code_files, docs issue_type)
- [x] Integration tests verifying stages are actually skipped in full pipeline runs
- [x] Code review passed (1 warning fixed — stale docstring)